### PR TITLE
feat: keyboard shortcuts for study mode

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -13,6 +13,7 @@ User-facing capabilities are documented here. New ideas and backlog items are tr
 ### Study workflow
 
 - Review mode with flip-to-reveal, progress tracking, and confidence ratings.
+- Keyboard-first study controls (`Space` to reveal, `1-4` to rate confidence) with on-screen hints.
 - SM-2 scheduling with due-card filtering and stage progression.
 - Session and event tracking for streaks, activity, and accuracy metrics.
 

--- a/docs/plans/issue-11-study-keyboard-shortcuts.md
+++ b/docs/plans/issue-11-study-keyboard-shortcuts.md
@@ -1,0 +1,46 @@
+# Issue #11 Plan: Keyboard Shortcuts for Study Mode
+
+Issue: https://github.com/aberiggs/flashcards/issues/11
+
+## Goal
+
+Add keyboard shortcuts to `/decks/[id]/study` so review can be completed without reaching for the mouse.
+
+## Scope
+
+- Add `Space` to reveal the answer when the question side is visible.
+- Add `1` / `2` / `3` / `4` to select `Wrong` / `Close` / `Hard` / `Easy` when the answer side is visible.
+- Make shortcuts inactive while focus is in text entry contexts (`input`, `textarea`, `select`, or contentEditable).
+- Add visual affordances for discoverability (button labels and a compact shortcut hint).
+
+## Implementation Plan
+
+1. Add a `keydown` listener effect in `src/app/(protected)/decks/[id]/study/page.tsx`.
+2. Guard shortcut handling with an active-element check for text-entry contexts.
+3. Wire `Space` to `handleShowAnswer()` only when `showAnswer` is false.
+4. Wire numeric shortcuts to existing `handleConfidence(...)` flows.
+5. Add visible key labels (`1`, `2`, `3`, `4`) to confidence buttons plus one-line hint text.
+6. Run lint/type-check and confirm no behavior regressions.
+
+## Explicit Decisions (for review later)
+
+- Decision: Use raw `keydown` + numeric keys (`1`-`4`) rather than numpad-specific handling.
+  - Why: Simpler and aligns with proposed acceptance criteria.
+  - Revisit: Add explicit numpad support if users report inconsistency.
+
+- Decision: Keep shortcuts globally active on the page except in text-entry contexts.
+  - Why: There are no editable fields on normal study UI, so this maximizes speed.
+  - Revisit: Scope to card container if future UI adds interactive controls.
+
+- Decision: Add persistent visible shortcut hints directly near confidence controls.
+  - Why: New users discover shortcuts without opening a help modal.
+  - Revisit: Replace with tooltip/help drawer if UI density becomes an issue.
+
+## Validation Checklist
+
+- [ ] Space reveals answer when on question side.
+- [ ] `1`/`2`/`3`/`4` map to `Wrong`/`Close`/`Hard`/`Easy` on answer side.
+- [ ] Key handling does not fire while typing in form fields.
+- [ ] Shortcut hints are visible and understandable.
+- [ ] `npm run lint` passes.
+- [ ] `npx tsc --noEmit` passes.

--- a/src/app/(protected)/decks/[id]/study/page.tsx
+++ b/src/app/(protected)/decks/[id]/study/page.tsx
@@ -48,6 +48,7 @@ export default function StudyPage() {
     // Freeze study order at session start so Convex live updates don't re-sort
     // mid-session (which would show the same card again after studying it)
     const [sessionCards, setSessionCards] = useState<NonNullable<typeof dueCards> | null>(null);
+    const confidenceLockRef = useRef(false);
 
     // Keep a ref to current session state so the cleanup effect can read it without stale closures
     const sessionStateRef = useRef({ sessionId: null as Id<"studySessions"> | null, cardsCorrect: 0, cardsIncorrect: 0, sessionComplete: false });
@@ -82,46 +83,51 @@ export default function StudyPage() {
     const progress = studyCards.length > 0 ? ((currentCardIndex + 1) / studyCards.length) * 100 : 0;
 
     const handleConfidence = useCallback(async (confidence: ConfidenceLevel) => {
-        if (!currentCard) return;
+        if (!currentCard || confidenceLockRef.current) return;
+        confidenceLockRef.current = true;
 
-        const quality = qualityFromConfidence[confidence];
-        const isCorrect = quality >= 3;
+        try {
+            const quality = qualityFromConfidence[confidence];
+            const isCorrect = quality >= 3;
 
-        if (isCorrect) {
-            setCardsCorrect((c) => c + 1);
-        } else {
-            setCardsIncorrect((c) => c + 1);
-        }
+            if (isCorrect) {
+                setCardsCorrect((c) => c + 1);
+            } else {
+                setCardsIncorrect((c) => c + 1);
+            }
 
-        await recordReviewMutation({
-            id: currentCard._id,
-            confidence,
-        });
-
-        if (sessionId) {
-            await recordEventMutation({
-                sessionId,
-                cardId: currentCard._id,
-                deckId,
-                quality,
+            await recordReviewMutation({
+                id: currentCard._id,
+                confidence,
             });
-        }
 
-        if (currentCardIndex < studyCards.length - 1) {
-            setCurrentCardIndex(currentCardIndex + 1);
-            setShowAnswer(false);
-        } else {
-            const finalCorrect = isCorrect ? cardsCorrect + 1 : cardsCorrect;
-            const finalIncorrect = isCorrect ? cardsIncorrect : cardsIncorrect + 1;
             if (sessionId) {
-                await completeSessionMutation({
+                await recordEventMutation({
                     sessionId,
-                    cardsStudied: studyCards.length,
-                    cardsCorrect: finalCorrect,
-                    cardsIncorrect: finalIncorrect,
+                    cardId: currentCard._id,
+                    deckId,
+                    quality,
                 });
             }
-            setSessionComplete(true);
+
+            if (currentCardIndex < studyCards.length - 1) {
+                setCurrentCardIndex(currentCardIndex + 1);
+                setShowAnswer(false);
+            } else {
+                const finalCorrect = isCorrect ? cardsCorrect + 1 : cardsCorrect;
+                const finalIncorrect = isCorrect ? cardsIncorrect : cardsIncorrect + 1;
+                if (sessionId) {
+                    await completeSessionMutation({
+                        sessionId,
+                        cardsStudied: studyCards.length,
+                        cardsCorrect: finalCorrect,
+                        cardsIncorrect: finalIncorrect,
+                    });
+                }
+                setSessionComplete(true);
+            }
+        } finally {
+            confidenceLockRef.current = false;
         }
     }, [
         cardsCorrect,
@@ -143,6 +149,7 @@ export default function StudyPage() {
     useEffect(() => {
         const onKeyDown = (event: KeyboardEvent) => {
             if (isTypingTarget(event.target)) return;
+            if (event.repeat) return;
 
             if (event.key === ' ' && !showAnswer) {
                 event.preventDefault();
@@ -178,7 +185,7 @@ export default function StudyPage() {
     // Loading state (include brief init when cards loaded but session order not yet frozen)
     if (deck === undefined || dueCards === undefined || allCards === undefined || (dueCards && dueCards.length > 0 && sessionCards === null && !sessionComplete)) {
         return (
-            <div className="min-h-screen bg-background text-foreground">
+            <div className="flex-1 bg-background text-foreground">
                 <AppHeader title="Study" backHref="/decks" backLabel="Decks" />
                 <main className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
                     <PageLoader message="Loading…" />
@@ -189,7 +196,7 @@ export default function StudyPage() {
 
     if (!deck) {
         return (
-            <div className="min-h-screen bg-background text-foreground">
+            <div className="flex-1 bg-background text-foreground">
                 <AppHeader title="Study" backHref="/decks" backLabel="Decks" />
                 <main className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8 flex items-center justify-center">
                     <div className="text-center">
@@ -213,7 +220,7 @@ export default function StudyPage() {
     if (!hasCardsToStudy) {
         if (hasNoCards) {
             return (
-                <div className="min-h-screen bg-background text-foreground">
+                <div className="flex-1 bg-background text-foreground">
                     <AppHeader
                         title={`Studying: ${deck.name}`}
                         backHref="/decks"
@@ -239,7 +246,7 @@ export default function StudyPage() {
         }
         if (hasNoDueCards && !sessionComplete) {
             return (
-                <div className="min-h-screen bg-background text-foreground">
+                <div className="flex-1 bg-background text-foreground">
                     <AppHeader
                         title={`Studying: ${deck.name}`}
                         backHref="/decks"
@@ -269,7 +276,7 @@ export default function StudyPage() {
 
     if (sessionComplete) {
         return (
-            <div className="min-h-screen bg-background text-foreground flex items-center justify-center">
+            <div className="flex-1 bg-background text-foreground flex items-center justify-center">
                 <div className="text-center">
                     <div className="w-16 h-16 mx-auto mb-4 bg-status-success-bg rounded-full flex items-center justify-center">
                         <Check className="w-8 h-8 text-status-success-text" aria-hidden />
@@ -291,7 +298,7 @@ export default function StudyPage() {
     }
 
     return (
-        <div className="min-h-screen bg-background text-foreground">
+        <div className="flex-1 bg-background text-foreground">
             <AppHeader
                 title={`Studying: ${deck.name}`}
                 backHref="/decks"
@@ -335,6 +342,7 @@ export default function StudyPage() {
                                 >
                                     Show Answer
                                 </button>
+                                <p className="mt-3 text-xs text-text-tertiary">Shortcut: Space reveals answer</p>
                             </div>
                         ) : (
                             // Back of card with confidence buttons
@@ -387,7 +395,7 @@ export default function StudyPage() {
                                             <span className="text-xs opacity-80">4</span>
                                         </button>
                                     </div>
-                                    <p className="text-xs text-text-tertiary">Shortcuts: Space reveals answer, 1-4 rate confidence</p>
+                                    <p className="text-xs text-text-tertiary">Shortcuts: 1-4 rate confidence</p>
                                 </div>
                             </div>
                         )}

--- a/src/app/(protected)/decks/[id]/study/page.tsx
+++ b/src/app/(protected)/decks/[id]/study/page.tsx
@@ -150,6 +150,7 @@ export default function StudyPage() {
         const onKeyDown = (event: KeyboardEvent) => {
             if (isTypingTarget(event.target)) return;
             if (event.repeat) return;
+            if (!currentCard || sessionComplete) return;
 
             if (event.key === ' ' && !showAnswer) {
                 event.preventDefault();
@@ -180,7 +181,7 @@ export default function StudyPage() {
         return () => {
             document.removeEventListener('keydown', onKeyDown);
         };
-    }, [showAnswer, handleShowAnswer, handleConfidence]);
+    }, [currentCard, sessionComplete, showAnswer, handleShowAnswer, handleConfidence]);
 
     // Loading state (include brief init when cards loaded but session order not yet frozen)
     if (deck === undefined || dueCards === undefined || allCards === undefined || (dueCards && dueCards.length > 0 && sessionCards === null && !sessionComplete)) {

--- a/src/app/(protected)/decks/[id]/study/page.tsx
+++ b/src/app/(protected)/decks/[id]/study/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useParams } from 'next/navigation';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { BookOpen, Check, HelpCircle, Lightbulb, X, AlertCircle } from 'lucide-react';
 import { useQuery, useMutation } from 'convex/react';
 import { api } from '../../../../../../convex/_generated/api';
@@ -20,6 +20,12 @@ const qualityFromConfidence: Record<ConfidenceLevel, number> = {
     hard: 3,
     easy: 5,
 };
+
+function isTypingTarget(target: EventTarget | null): boolean {
+    if (!(target instanceof HTMLElement)) return false;
+    const tagName = target.tagName;
+    return target.isContentEditable || tagName === 'INPUT' || tagName === 'TEXTAREA' || tagName === 'SELECT';
+}
 
 export default function StudyPage() {
     const { id } = useParams();
@@ -72,6 +78,102 @@ export default function StudyPage() {
     }, []);
 
     const studyCards = sessionCards ?? [];
+    const currentCard = studyCards[currentCardIndex];
+    const progress = studyCards.length > 0 ? ((currentCardIndex + 1) / studyCards.length) * 100 : 0;
+
+    const handleConfidence = useCallback(async (confidence: ConfidenceLevel) => {
+        if (!currentCard) return;
+
+        const quality = qualityFromConfidence[confidence];
+        const isCorrect = quality >= 3;
+
+        if (isCorrect) {
+            setCardsCorrect((c) => c + 1);
+        } else {
+            setCardsIncorrect((c) => c + 1);
+        }
+
+        await recordReviewMutation({
+            id: currentCard._id,
+            confidence,
+        });
+
+        if (sessionId) {
+            await recordEventMutation({
+                sessionId,
+                cardId: currentCard._id,
+                deckId,
+                quality,
+            });
+        }
+
+        if (currentCardIndex < studyCards.length - 1) {
+            setCurrentCardIndex(currentCardIndex + 1);
+            setShowAnswer(false);
+        } else {
+            const finalCorrect = isCorrect ? cardsCorrect + 1 : cardsCorrect;
+            const finalIncorrect = isCorrect ? cardsIncorrect : cardsIncorrect + 1;
+            if (sessionId) {
+                await completeSessionMutation({
+                    sessionId,
+                    cardsStudied: studyCards.length,
+                    cardsCorrect: finalCorrect,
+                    cardsIncorrect: finalIncorrect,
+                });
+            }
+            setSessionComplete(true);
+        }
+    }, [
+        cardsCorrect,
+        cardsIncorrect,
+        completeSessionMutation,
+        currentCard,
+        currentCardIndex,
+        deckId,
+        recordEventMutation,
+        recordReviewMutation,
+        sessionId,
+        studyCards.length,
+    ]);
+
+    const handleShowAnswer = useCallback(() => {
+        setShowAnswer(true);
+    }, []);
+
+    useEffect(() => {
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (isTypingTarget(event.target)) return;
+
+            if (event.key === ' ' && !showAnswer) {
+                event.preventDefault();
+                handleShowAnswer();
+                return;
+            }
+
+            if (event.key === '1' || event.key === '2' || event.key === '3' || event.key === '4') {
+                if (!showAnswer) return;
+                event.preventDefault();
+                if (event.key === '1') {
+                    void handleConfidence('wrong');
+                    return;
+                }
+                if (event.key === '2') {
+                    void handleConfidence('close');
+                    return;
+                }
+                if (event.key === '3') {
+                    void handleConfidence('hard');
+                    return;
+                }
+                void handleConfidence('easy');
+            }
+        };
+
+        document.addEventListener('keydown', onKeyDown);
+        return () => {
+            document.removeEventListener('keydown', onKeyDown);
+        };
+    }, [showAnswer, handleShowAnswer, handleConfidence]);
 
     // Loading state (include brief init when cards loaded but session order not yet frozen)
     if (deck === undefined || dueCards === undefined || allCards === undefined || (dueCards && dueCards.length > 0 && sessionCards === null && !sessionComplete)) {
@@ -188,56 +290,6 @@ export default function StudyPage() {
         );
     }
 
-    const currentCard = studyCards[currentCardIndex];
-    const progress = ((currentCardIndex + 1) / studyCards.length) * 100;
-
-    const handleConfidence = async (confidence: ConfidenceLevel) => {
-        const quality = qualityFromConfidence[confidence];
-        const isCorrect = quality >= 3;
-
-        if (isCorrect) {
-            setCardsCorrect((c) => c + 1);
-        } else {
-            setCardsIncorrect((c) => c + 1);
-        }
-
-        await recordReviewMutation({
-            id: currentCard._id,
-            confidence,
-        });
-
-        if (sessionId) {
-            await recordEventMutation({
-                sessionId,
-                cardId: currentCard._id,
-                deckId,
-                quality,
-            });
-        }
-
-        // Move to next card or complete session
-        if (currentCardIndex < studyCards.length - 1) {
-            setCurrentCardIndex(currentCardIndex + 1);
-            setShowAnswer(false);
-        } else {
-            const finalCorrect = isCorrect ? cardsCorrect + 1 : cardsCorrect;
-            const finalIncorrect = isCorrect ? cardsIncorrect : cardsIncorrect + 1;
-            if (sessionId) {
-                await completeSessionMutation({
-                    sessionId,
-                    cardsStudied: studyCards.length,
-                    cardsCorrect: finalCorrect,
-                    cardsIncorrect: finalIncorrect,
-                });
-            }
-            setSessionComplete(true);
-        }
-    };
-
-    const handleShowAnswer = () => {
-        setShowAnswer(true);
-    };
-
     return (
         <div className="min-h-screen bg-background text-foreground">
             <AppHeader
@@ -308,6 +360,7 @@ export default function StudyPage() {
                                         >
                                             <X className="w-5 h-5 shrink-0" aria-hidden />
                                             <span className="font-medium">Wrong</span>
+                                            <span className="text-xs opacity-80">1</span>
                                         </button>
                                         <button
                                             onClick={() => handleConfidence('close')}
@@ -315,6 +368,7 @@ export default function StudyPage() {
                                         >
                                             <AlertCircle className="w-5 h-5 shrink-0" aria-hidden />
                                             <span className="font-medium">Close</span>
+                                            <span className="text-xs opacity-80">2</span>
                                         </button>
                                         <button
                                             onClick={() => handleConfidence('hard')}
@@ -322,6 +376,7 @@ export default function StudyPage() {
                                         >
                                             <HelpCircle className="w-5 h-5 shrink-0" aria-hidden />
                                             <span className="font-medium">Hard</span>
+                                            <span className="text-xs opacity-80">3</span>
                                         </button>
                                         <button
                                             onClick={() => handleConfidence('easy')}
@@ -329,8 +384,10 @@ export default function StudyPage() {
                                         >
                                             <Check className="w-5 h-5 shrink-0" aria-hidden />
                                             <span className="font-medium">Easy</span>
+                                            <span className="text-xs opacity-80">4</span>
                                         </button>
                                     </div>
+                                    <p className="text-xs text-text-tertiary">Shortcuts: Space reveals answer, 1-4 rate confidence</p>
                                 </div>
                             </div>
                         )}


### PR DESCRIPTION
## Summary
- add study-page keyboard shortcuts: `Space` reveals answer and `1-4` maps to Wrong/Close/Hard/Easy
- ignore shortcuts while focus is in text-entry contexts (`input`, `textarea`, `select`, contentEditable)
- add visible shortcut hints on confidence buttons and helper text for discoverability

## Validation
- npm run lint
- npx tsc --noEmit

Closes #11