### PR TITLE
feat: bulk generate reverse cards per deck

### DIFF
--- a/convex/cards.ts
+++ b/convex/cards.ts
@@ -8,6 +8,10 @@ import {
 } from "./sm2";
 import { MAX_CARDS_PER_DECK, MAX_CARDS_PER_USER } from "./limits";
 
+function normalizeCardSide(value: string): string {
+  return value.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
 // Get all cards for a deck
 export const getByDeck = query({
   args: { deckId: v.id("decks") },
@@ -66,6 +70,178 @@ export const getDueByDeck = query({
     });
 
     return dueCards;
+  },
+});
+
+export const reverseGenerationSummary = query({
+  args: { deckId: v.id("decks") },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) return null;
+
+    const deck = await ctx.db.get(args.deckId);
+    if (!deck || deck.userId !== userId) return null;
+
+    const cards = await ctx.db
+      .query("cards")
+      .withIndex("by_deck", (q) => q.eq("deckId", args.deckId))
+      .collect();
+
+    const existingPairs = new Set(
+      cards.map((card) => `${normalizeCardSide(card.front)}\u0000${normalizeCardSide(card.back)}`)
+    );
+
+    const candidates = new Map<string, { front: string; back: string }>();
+    let skippedExistingReverseCount = 0;
+    let skippedDuplicateCandidateCount = 0;
+
+    for (const card of cards) {
+      const reverseFront = card.back.trim();
+      const reverseBack = card.front.trim();
+      const reverseKey = `${normalizeCardSide(reverseFront)}\u0000${normalizeCardSide(reverseBack)}`;
+
+      if (existingPairs.has(reverseKey)) {
+        skippedExistingReverseCount++;
+        continue;
+      }
+
+      if (candidates.has(reverseKey)) {
+        skippedDuplicateCandidateCount++;
+        continue;
+      }
+
+      candidates.set(reverseKey, {
+        front: reverseFront,
+        back: reverseBack,
+      });
+    }
+
+    const cardsToCreateCount = candidates.size;
+    const remainingDeckCapacity = Math.max(0, MAX_CARDS_PER_DECK - cards.length);
+    const deckLimitExceeded = cardsToCreateCount > remainingDeckCapacity;
+
+    const decks = await ctx.db
+      .query("decks")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .collect();
+    let totalCards = 0;
+    for (const userDeck of decks) {
+      const count = await ctx.db
+        .query("cards")
+        .withIndex("by_deck", (q) => q.eq("deckId", userDeck._id))
+        .collect()
+        .then((c) => c.length);
+      totalCards += count;
+      if (totalCards >= MAX_CARDS_PER_USER) break;
+    }
+
+    const remainingUserCapacity = Math.max(0, MAX_CARDS_PER_USER - totalCards);
+    const userLimitExceeded = cardsToCreateCount > remainingUserCapacity;
+
+    return {
+      totalCardsInDeck: cards.length,
+      cardsToCreateCount,
+      skippedExistingReverseCount,
+      skippedDuplicateCandidateCount,
+      remainingDeckCapacity,
+      remainingUserCapacity,
+      deckLimitExceeded,
+      userLimitExceeded,
+    };
+  },
+});
+
+export const generateReverseCards = mutation({
+  args: { deckId: v.id("decks") },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) throw new Error("Not authenticated");
+
+    const deck = await ctx.db.get(args.deckId);
+    if (!deck || deck.userId !== userId) throw new Error("Deck not found");
+
+    const cards = await ctx.db
+      .query("cards")
+      .withIndex("by_deck", (q) => q.eq("deckId", args.deckId))
+      .collect();
+
+    const existingPairs = new Set(
+      cards.map((card) => `${normalizeCardSide(card.front)}\u0000${normalizeCardSide(card.back)}`)
+    );
+
+    const candidates = new Map<string, { front: string; back: string }>();
+    let skippedExistingReverseCount = 0;
+    let skippedDuplicateCandidateCount = 0;
+
+    for (const card of cards) {
+      const reverseFront = card.back.trim();
+      const reverseBack = card.front.trim();
+      const reverseKey = `${normalizeCardSide(reverseFront)}\u0000${normalizeCardSide(reverseBack)}`;
+
+      if (existingPairs.has(reverseKey)) {
+        skippedExistingReverseCount++;
+        continue;
+      }
+
+      if (candidates.has(reverseKey)) {
+        skippedDuplicateCandidateCount++;
+        continue;
+      }
+
+      candidates.set(reverseKey, {
+        front: reverseFront,
+        back: reverseBack,
+      });
+    }
+
+    const cardsToCreate = Array.from(candidates.values());
+    const remainingDeckCapacity = MAX_CARDS_PER_DECK - cards.length;
+    if (cardsToCreate.length > remainingDeckCapacity) {
+      throw new Error(
+        `Generating ${cardsToCreate.length} reverse cards would exceed this deck's limit of ${MAX_CARDS_PER_DECK}. Only ${Math.max(0, remainingDeckCapacity)} more card${remainingDeckCapacity === 1 ? "" : "s"} can be added.`
+      );
+    }
+
+    const decks = await ctx.db
+      .query("decks")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .collect();
+    let totalCards = 0;
+    for (const userDeck of decks) {
+      const count = await ctx.db
+        .query("cards")
+        .withIndex("by_deck", (q) => q.eq("deckId", userDeck._id))
+        .collect()
+        .then((c) => c.length);
+      totalCards += count;
+      if (totalCards >= MAX_CARDS_PER_USER) break;
+    }
+
+    const remainingUserCapacity = MAX_CARDS_PER_USER - totalCards;
+    if (cardsToCreate.length > remainingUserCapacity) {
+      throw new Error(
+        `Generating ${cardsToCreate.length} reverse cards would exceed your total limit of ${MAX_CARDS_PER_USER.toLocaleString()} cards. Only ${Math.max(0, remainingUserCapacity)} more card${remainingUserCapacity === 1 ? "" : "s"} can be added.`
+      );
+    }
+
+    if (cardsToCreate.length > 0) {
+      const now = Date.now();
+      for (const card of cardsToCreate) {
+        await ctx.db.insert("cards", {
+          deckId: args.deckId,
+          front: card.front,
+          back: card.back,
+          updatedAt: now,
+        });
+      }
+      await ctx.db.patch(args.deckId, { updatedAt: now });
+    }
+
+    return {
+      createdCount: cardsToCreate.length,
+      skippedExistingReverseCount,
+      skippedDuplicateCandidateCount,
+    };
   },
 });
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -7,6 +7,7 @@ User-facing capabilities are documented here. New ideas and backlog items are tr
 ### Decks and cards
 
 - Create, edit, and remove decks and cards.
+- Generate reverse cards (answer -> question) in bulk with duplicate/capacity safeguards.
 - View card counts, due counts, and last-studied order on decks.
 - Render card content as Markdown (paragraphs, emphasis, lists, inline code).
 

--- a/docs/plans/issue-12-reverse-cards.md
+++ b/docs/plans/issue-12-reverse-cards.md
@@ -1,0 +1,50 @@
+# Issue #12 Plan: Reverse Cards (Answer -> Question)
+
+Issue: https://github.com/aberiggs/flashcards/issues/12
+
+## Goal
+
+Allow one-click generation of reverse cards for a deck while avoiding duplicates and enforcing deck/user card limits.
+
+## Scope
+
+- Add a deck-level action to generate reverse cards.
+- Add a confirmation modal that previews how many cards will be created.
+- Skip reverse cards that already exist.
+- Skip duplicate reverse candidates created by repeated/similar source cards.
+- Enforce per-deck and per-user card limits with clear errors.
+- Keep reverse cards as normal persisted cards with fresh SM-2 state.
+
+## Implementation Plan
+
+1. Add Convex query for reverse-generation preview (counts + capacity checks).
+2. Add Convex mutation to create reverse cards and return creation/skip stats.
+3. Add deck page CTA (`Generate reverse cards`) near card-management actions.
+4. Add confirmation modal with creation count, skip counts, and capacity summary.
+5. Disable confirmation when limits are exceeded.
+6. Show success/error toasts with outcome details.
+7. Run lint/type-check.
+
+## Explicit Decisions (for review later)
+
+- Decision: Persist reverse cards as separate DB rows instead of virtual rendering.
+  - Why: Matches issue expectation for independent SM-2 progression by direction.
+  - Revisit: Evaluate virtual bidirectional mode if card-edit synchronization becomes a pain point.
+
+- Decision: Deduplicate using normalized text pairs (`trim + collapse whitespace + lowercase`) for `front/back`.
+  - Why: Avoid near-identical duplicate reverses caused by casing/spacing differences.
+  - Revisit: Could become too aggressive for case-sensitive topics (e.g., coding symbols, proper nouns).
+
+- Decision: Keep reverse generation as a separate action on deck detail page (not bundled into AI generation flow yet).
+  - Why: Smaller scope and clearer behavior for beta launch.
+  - Revisit: Add optional "also generate reverses" toggle in AI flow later.
+
+## Validation Checklist
+
+- [ ] User can open reverse-generation confirmation from deck page.
+- [ ] Confirmation shows how many reverses will be created before write.
+- [ ] Existing reverses and duplicate candidates are skipped.
+- [ ] Deck/user limits are validated and blocking errors are clear.
+- [ ] New reverses have fresh SM-2 state (no carried schedule).
+- [ ] `npm run lint` passes.
+- [ ] `npx tsc --noEmit` passes.

--- a/src/app/(protected)/decks/[id]/page.tsx
+++ b/src/app/(protected)/decks/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useParams, useRouter } from 'next/navigation';
 import { useState, useEffect, useRef } from 'react';
-import { Pencil, Trash2, Plus, Layers, Sparkles } from 'lucide-react';
+import { Pencil, Trash2, Plus, Layers, Sparkles, Repeat } from 'lucide-react';
 import { useQuery, useMutation } from 'convex/react';
 import { api } from '../../../../../convex/_generated/api';
 import type { Id } from '../../../../../convex/_generated/dataModel';
@@ -44,6 +44,7 @@ export default function DeckDetailPage() {
     const addCardMutation = useMutation(api.cards.create);
     const updateCardMutation = useMutation(api.cards.update);
     const deleteCardMutation = useMutation(api.cards.remove);
+    const generateReverseCardsMutation = useMutation(api.cards.generateReverseCards);
 
     const [editingName, setEditingName] = useState(false);
     const [editingDescription, setEditingDescription] = useState(false);
@@ -55,11 +56,18 @@ export default function DeckDetailPage() {
     const [isDeleteCardModalOpen, setIsDeleteCardModalOpen] = useState(false);
     const [cardToDeleteId, setCardToDeleteId] = useState<Id<"cards"> | null>(null);
     const [isGenerateModalOpen, setIsGenerateModalOpen] = useState(false);
+    const [isGenerateReverseModalOpen, setIsGenerateReverseModalOpen] = useState(false);
+    const [isGeneratingReverseCards, setIsGeneratingReverseCards] = useState(false);
     const [isDeletingCard, setIsDeletingCard] = useState(false);
     const [isDeletingDeck, setIsDeletingDeck] = useState(false);
     const [viewingCardIndex, setViewingCardIndex] = useState<number | null>(null);
     const [showingCardInfo, setShowingCardInfo] = useState(false);
     const [infoCardIndex, setInfoCardIndex] = useState(0);
+
+    const reverseSummary = useQuery(
+        api.cards.reverseGenerationSummary,
+        deckWithCards && isGenerateReverseModalOpen ? { deckId } : 'skip'
+    );
 
     const nameInputRef = useRef<HTMLInputElement>(null);
 
@@ -220,6 +228,23 @@ export default function DeckDetailPage() {
         setAddForm({ front: '', back: '' });
     };
 
+    const handleGenerateReverseCards = async () => {
+        setIsGeneratingReverseCards(true);
+        try {
+            const result = await generateReverseCardsMutation({ deckId });
+            if (result.createdCount === 0) {
+                toast.success('No new reverse cards to create. Existing reverses were skipped.');
+            } else {
+                toast.success(`Created ${result.createdCount} reverse card${result.createdCount === 1 ? '' : 's'}`);
+            }
+            setIsGenerateReverseModalOpen(false);
+        } catch (err) {
+            toast.error(err instanceof Error ? err.message : 'Failed to generate reverse cards');
+        } finally {
+            setIsGeneratingReverseCards(false);
+        }
+    };
+
     return (
         <div className="min-h-screen bg-background text-foreground">
             <AppHeader title={deckWithCards.name} backHref="/decks" backLabel="Decks" />
@@ -342,6 +367,15 @@ export default function DeckDetailPage() {
                     <div className="flex items-center justify-between mb-4">
                         <h2 className="text-lg font-semibold text-text-primary">Cards</h2>
                         <div className="flex items-center gap-2">
+                            <button
+                                type="button"
+                                onClick={() => setIsGenerateReverseModalOpen(true)}
+                                disabled={cards.length === 0}
+                                className="inline-flex items-center gap-2 border border-border-primary text-text-primary px-4 py-2.5 rounded-lg text-sm font-medium hover:bg-surface-secondary transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-accent-primary focus:ring-offset-2 focus:ring-offset-surface-primary"
+                            >
+                                <Repeat className="w-4 h-4" aria-hidden />
+                                Generate reverse cards
+                            </button>
                             <button
                                 type="button"
                                 onClick={() => setIsGenerateModalOpen(true)}
@@ -520,6 +554,64 @@ export default function DeckDetailPage() {
                 onClose={() => setIsGenerateModalOpen(false)}
                 deckId={deckId}
             />
+
+            {/* Generate Reverse Cards Modal */}
+            <Modal
+                isOpen={isGenerateReverseModalOpen}
+                onClose={() => {
+                    if (!isGeneratingReverseCards) {
+                        setIsGenerateReverseModalOpen(false);
+                    }
+                }}
+                title="Generate reverse cards"
+            >
+                {reverseSummary === undefined ? (
+                    <p className="text-sm text-text-secondary">Calculating reverse card preview…</p>
+                ) : reverseSummary === null ? (
+                    <p className="text-sm text-text-secondary">Unable to load reverse card summary.</p>
+                ) : (
+                    <div className="space-y-4">
+                        <p className="text-sm text-text-secondary">
+                            This will create <span className="font-semibold text-text-primary">{reverseSummary.cardsToCreateCount}</span> reverse card{reverseSummary.cardsToCreateCount === 1 ? '' : 's'} by swapping front and back.
+                        </p>
+                        <ul className="text-sm text-text-secondary space-y-1">
+                            <li>Skipped existing reverses: {reverseSummary.skippedExistingReverseCount}</li>
+                            <li>Skipped duplicate reverses: {reverseSummary.skippedDuplicateCandidateCount}</li>
+                            <li>Deck capacity remaining: {reverseSummary.remainingDeckCapacity}</li>
+                            <li>Total capacity remaining: {reverseSummary.remainingUserCapacity}</li>
+                        </ul>
+                        {(reverseSummary.deckLimitExceeded || reverseSummary.userLimitExceeded) && (
+                            <p className="text-sm text-accent-error">
+                                This action would exceed card limits. Remove cards or split content before generating reverses.
+                            </p>
+                        )}
+                    </div>
+                )}
+                <div className="flex gap-2 justify-end mt-6">
+                    <button
+                        type="button"
+                        onClick={() => setIsGenerateReverseModalOpen(false)}
+                        disabled={isGeneratingReverseCards}
+                        className="px-4 py-2.5 rounded-lg text-sm font-medium border border-border-primary text-text-primary hover:bg-surface-secondary transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                        Cancel
+                    </button>
+                    <button
+                        type="button"
+                        onClick={handleGenerateReverseCards}
+                        disabled={
+                            isGeneratingReverseCards ||
+                            reverseSummary === undefined ||
+                            reverseSummary === null ||
+                            reverseSummary.deckLimitExceeded ||
+                            reverseSummary.userLimitExceeded
+                        }
+                        className="px-4 py-2.5 rounded-lg text-sm font-medium bg-accent-primary text-text-inverse hover:bg-accent-primary-hover transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                        {isGeneratingReverseCards ? 'Generating…' : 'Generate'}
+                    </button>
+                </div>
+            </Modal>
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- add reverse-card generation preview and creation APIs in Convex with duplicate skipping
- enforce deck/user card limits during preview and at write time with clear limit errors
- add deck-page confirmation modal showing cards-to-create, skipped counts, and remaining capacity

## Validation
- npm run lint
- npx tsc --noEmit

Closes #12