### PR TITLE
feat: add "Explain this" assistance in study mode

### DIFF
--- a/convex/ai.ts
+++ b/convex/ai.ts
@@ -256,6 +256,79 @@ ${existingFronts}`;
   },
 });
 
+export const explainCard = action({
+  args: {
+    front: v.string(),
+    back: v.string(),
+  },
+  handler: async (ctx, args): Promise<string> => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) throw new Error("Not authenticated");
+
+    const settings = await ctx.runQuery(internal.settings.getInternal, {
+      userId,
+    });
+    if (!settings?.openAiApiKey) {
+      throw new Error("No OpenAI API key configured. Add one in Settings.");
+    }
+
+    const systemPrompt = `You are a study coach for flashcard learners.
+Given a flashcard front (question/prompt) and back (answer), provide a short explanation that helps the learner understand and remember the fact.
+
+Output requirements:
+- Keep it concise: 3-6 sentences unless examples are clearly helpful.
+- Focus on understanding, not just restating the answer.
+- Use plain language and avoid jargon where possible.
+
+Domain-aware guidance:
+- If the card is historical (events, people, dates, causes), include brief context: why it matters, what led to it, or an important consequence.
+- If the card is language-learning (vocabulary, grammar, translation), include 1-2 short example sentences showing natural usage.
+- If neither applies, provide one practical memory aid (comparison, pattern, or mnemonic cue).
+
+Return plain markdown text only.`;
+
+    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${settings.openAiApiKey}`,
+      },
+      body: JSON.stringify({
+        model: "gpt-4o-mini",
+        messages: [
+          { role: "system", content: systemPrompt },
+          {
+            role: "user",
+            content: `Front: ${args.front}\nBack: ${args.back}`,
+          },
+        ],
+        temperature: 0.4,
+        max_tokens: 500,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      if (response.status === 401) {
+        throw new Error("Invalid OpenAI API key. Check your key in Settings.");
+      }
+      throw new Error(
+        `OpenAI API error (${response.status}): ${errorText.slice(0, 200)}`
+      );
+    }
+
+    const data = await response.json();
+    const content: string = data.choices?.[0]?.message?.content ?? "";
+
+    const explanation = content.trim();
+    if (!explanation) {
+      throw new Error("AI returned an empty explanation. Try again.");
+    }
+
+    return explanation;
+  },
+});
+
 export const insertGeneratedCards = action({
   args: {
     deckId: v.id("decks"),

--- a/docs/features.md
+++ b/docs/features.md
@@ -27,6 +27,7 @@ User-facing capabilities are documented here. New ideas and backlog items are tr
 - Generate cards from topics or pasted notes.
 - Auto-select card counts by content depth, or choose 1-100 manually.
 - Deduplicate against existing deck cards, then preview/edit before saving.
+- Request an in-session "Explain this" breakdown for revealed study answers (BYOK required).
 
 ### Import and export
 

--- a/docs/plans/issue-14-explain-button.md
+++ b/docs/plans/issue-14-explain-button.md
@@ -1,0 +1,49 @@
+# Issue #14 Plan: "Explain this" Button During Study
+
+Issue: https://github.com/aberiggs/flashcards/issues/14
+
+## Goal
+
+Add an AI explanation affordance to study sessions so learners can get immediate context without leaving the app.
+
+## Scope
+
+- Add an `Explain` action in study mode when the answer is revealed.
+- Use BYOK OpenAI key requirement (same settings pattern as generation).
+- Add loading and error states.
+- Render explanation inline under the answer controls.
+- Keep explanations contextual to the current card content.
+- Cache explanations by card within the session to avoid duplicate API calls.
+
+## Implementation Plan
+
+1. Add a Convex AI action that takes card front/back and returns a concise explanation.
+2. Build a specialized system prompt to adapt output for different study domains.
+3. Integrate the action in `study/page.tsx` with loading/error/display states.
+4. Add per-session client cache keyed by card ID.
+5. Gate explain action by `settings.hasApiKey`.
+6. Update docs and validate lint/type-check.
+
+## Explicit Decisions (for review later)
+
+- Decision: Add domain-aware prompt guidance now (history context + language examples) instead of a generic explanation-only prompt.
+  - Why: Better learning utility for core beta use cases, aligned with product feedback.
+  - Revisit: Move to explicit user-selectable explanation styles (e.g., "concise", "examples", "mnemonic").
+
+- Decision: Implement explain UI in study mode first on this branch.
+  - Why: Keeps this PR scoped to issue #14 on current `main` while cram mode ships in its own PR.
+  - Revisit: Reuse the same explain panel/action in cram mode after cram PR merges.
+
+- Decision: Cache explanations only in-memory for the active session.
+  - Why: Avoids redundant calls without introducing persistence complexity.
+  - Revisit: Persist explanation cache server-side if repeated deck sessions become expensive.
+
+## Validation Checklist
+
+- [ ] Explain button appears when answer is shown and API key exists.
+- [ ] Explanation loads and displays in-context for the current card.
+- [ ] Loading state is visible while waiting for response.
+- [ ] Graceful error feedback appears on failure.
+- [ ] Cached explanation prevents repeated calls for same card in-session.
+- [ ] `npm run lint` passes.
+- [ ] `npx tsc --noEmit` passes.

--- a/src/app/(protected)/decks/[id]/study/page.tsx
+++ b/src/app/(protected)/decks/[id]/study/page.tsx
@@ -3,7 +3,7 @@
 import { useParams } from 'next/navigation';
 import { useState, useEffect, useRef } from 'react';
 import { BookOpen, Check, HelpCircle, Lightbulb, X, AlertCircle } from 'lucide-react';
-import { useQuery, useMutation } from 'convex/react';
+import { useQuery, useMutation, useAction } from 'convex/react';
 import { api } from '../../../../../../convex/_generated/api';
 import type { Id } from '../../../../../../convex/_generated/dataModel';
 import { Card } from '@/components/ui/Card';
@@ -28,10 +28,12 @@ export default function StudyPage() {
     const deck = useQuery(api.decks.get, { id: deckId });
     const dueCards = useQuery(api.cards.getDueByDeck, { deckId });
     const allCards = useQuery(api.cards.getByDeck, { deckId });
+    const settings = useQuery(api.settings.get);
     const recordReviewMutation = useMutation(api.cards.recordReview);
     const startSessionMutation = useMutation(api.sessions.startSession);
     const completeSessionMutation = useMutation(api.sessions.completeSession);
     const recordEventMutation = useMutation(api.sessions.recordEvent);
+    const explainCardAction = useAction(api.ai.explainCard);
 
     const [currentCardIndex, setCurrentCardIndex] = useState(0);
     const [showAnswer, setShowAnswer] = useState(false);
@@ -39,6 +41,9 @@ export default function StudyPage() {
     const [sessionId, setSessionId] = useState<Id<"studySessions"> | null>(null);
     const [cardsCorrect, setCardsCorrect] = useState(0);
     const [cardsIncorrect, setCardsIncorrect] = useState(0);
+    const [explanationByCard, setExplanationByCard] = useState<Record<string, string>>({});
+    const [isLoadingExplanation, setIsLoadingExplanation] = useState(false);
+    const [explanationError, setExplanationError] = useState<string | null>(null);
     // Freeze study order at session start so Convex live updates don't re-sort
     // mid-session (which would show the same card again after studying it)
     const [sessionCards, setSessionCards] = useState<NonNullable<typeof dueCards> | null>(null);
@@ -74,7 +79,7 @@ export default function StudyPage() {
     const studyCards = sessionCards ?? [];
 
     // Loading state (include brief init when cards loaded but session order not yet frozen)
-    if (deck === undefined || dueCards === undefined || allCards === undefined || (dueCards && dueCards.length > 0 && sessionCards === null && !sessionComplete)) {
+    if (deck === undefined || dueCards === undefined || allCards === undefined || settings === undefined || (dueCards && dueCards.length > 0 && sessionCards === null && !sessionComplete)) {
         return (
             <div className="min-h-screen bg-background text-foreground">
                 <AppHeader title="Study" backHref="/decks" backLabel="Decks" />
@@ -219,6 +224,7 @@ export default function StudyPage() {
         if (currentCardIndex < studyCards.length - 1) {
             setCurrentCardIndex(currentCardIndex + 1);
             setShowAnswer(false);
+            setExplanationError(null);
         } else {
             const finalCorrect = isCorrect ? cardsCorrect + 1 : cardsCorrect;
             const finalIncorrect = isCorrect ? cardsIncorrect : cardsIncorrect + 1;
@@ -236,6 +242,33 @@ export default function StudyPage() {
 
     const handleShowAnswer = () => {
         setShowAnswer(true);
+    };
+
+    const handleExplain = async () => {
+        if (!settings?.hasApiKey) return;
+
+        const existing = explanationByCard[currentCard._id];
+        if (existing) {
+            setExplanationError(null);
+            return;
+        }
+
+        setIsLoadingExplanation(true);
+        setExplanationError(null);
+        try {
+            const explanation = await explainCardAction({
+                front: currentCard.front,
+                back: currentCard.back,
+            });
+            setExplanationByCard((prev) => ({
+                ...prev,
+                [currentCard._id]: explanation,
+            }));
+        } catch (err) {
+            setExplanationError(err instanceof Error ? err.message : 'Failed to load explanation');
+        } finally {
+            setIsLoadingExplanation(false);
+        }
     };
 
     return (
@@ -301,6 +334,21 @@ export default function StudyPage() {
                                     <p className="text-text-tertiary font-medium">
                                         How did you do?
                                     </p>
+                                    {settings?.hasApiKey && (
+                                        <div className="max-w-md mx-auto w-full">
+                                            <button
+                                                type="button"
+                                                onClick={() => {
+                                                    void handleExplain();
+                                                }}
+                                                disabled={isLoadingExplanation}
+                                                className="w-full inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg text-sm font-medium border border-border-primary text-text-primary hover:bg-surface-secondary transition-colors cursor-pointer disabled:opacity-60 disabled:cursor-not-allowed"
+                                            >
+                                                <Lightbulb className="w-4 h-4" aria-hidden />
+                                                {isLoadingExplanation ? 'Explaining...' : 'Explain this'}
+                                            </button>
+                                        </div>
+                                    )}
                                     <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 sm:gap-4 max-w-md mx-auto w-full">
                                         <button
                                             onClick={() => handleConfidence('wrong')}
@@ -331,6 +379,17 @@ export default function StudyPage() {
                                             <span className="font-medium">Easy</span>
                                         </button>
                                     </div>
+                                    {explanationError && (
+                                        <p className="text-sm text-status-error-text max-w-2xl mx-auto">{explanationError}</p>
+                                    )}
+                                    {explanationByCard[currentCard._id] && (
+                                        <div className="max-w-2xl mx-auto text-left border border-border-primary bg-surface-secondary rounded-lg px-4 py-3">
+                                            <p className="text-xs uppercase tracking-wide text-text-tertiary mb-2">Explanation</p>
+                                            <div className="text-sm text-text-secondary leading-relaxed">
+                                                <MarkdownContent content={explanationByCard[currentCard._id]} />
+                                            </div>
+                                        </div>
+                                    )}
                                 </div>
                             </div>
                         )}


### PR DESCRIPTION
## Summary
- add new Convex AI action to explain a revealed flashcard answer with domain-aware guidance (history context and language examples)
- add `Explain this` button and inline explanation panel on the study page with loading, error, and per-session caching
- gate explanation feature behind user BYOK settings and keep existing review flow unchanged

## Validation
- npm run lint
- npx tsc --noEmit

Closes #14