### PR TITLE
Fix Dockerfile: copy drizzle/ into image; run migrations at startup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,9 +14,6 @@ docker-compose.yml
 .env*
 !.env.example
 
-# Drizzle migrations are copied explicitly in the Dockerfile
-drizzle
-
 # Docs / config not needed at runtime
 docs
 AGENTS.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1
-
 # ── Build stage ─────────────────────────────────────────────────────────────────
 FROM node:22-alpine AS builder
 
@@ -36,14 +34,26 @@ COPY --from=builder /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
-# Copy drizzle migrations so the entrypoint can run them
+# Copy drizzle migrations + config + schema so the entrypoint can run migrations
 COPY --from=builder --chown=nextjs:nodejs /app/drizzle ./drizzle
 COPY --from=builder --chown=nextjs:nodejs /app/drizzle.config.ts ./drizzle.config.ts
-COPY --from=builder --chown=nextjs:nodejs /app/package.json ./package.json
+COPY --from=builder --chown=nextjs:nodejs /app/src/db/schema.ts ./src/db/schema.ts
 
-# Install just drizzle-kit to run migrations at startup
-RUN npm install --omit=dev drizzle-kit postgres --no-audit --no-fund
+# Install drizzle-kit (to run migrations at startup), postgres (driver), and
+# dotenv (used by drizzle.config.ts) into /app/migrate — a separate node_modules
+# tree. The standalone build's /app/node_modules is a curated minimal tree;
+# running `npm install` there would prune it, so install elsewhere and point
+# NODE_PATH at it for drizzle.config.ts's require() resolution.
+RUN mkdir -p /app/migrate
+WORKDIR /app/migrate
+RUN npm init -y >/dev/null && \
+    npm install drizzle-kit drizzle-orm postgres dotenv --no-audit --no-fund
 
+# Entrypoint script: run migrations, then exec the server
+COPY --chown=nextjs:nodejs docker-entrypoint.sh ./docker-entrypoint.sh
+RUN chmod +x ./docker-entrypoint.sh
+
+WORKDIR /app
 USER nextjs
 
 EXPOSE 3000
@@ -51,5 +61,4 @@ EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME=0.0.0.0
 
-# Run migrations then start the server
-CMD npx drizzle-kit migrate && node server.js
+CMD ["./migrate/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+# Run DB migrations, then start the app. Migrations are idempotent —
+# drizzle-kit skips already-applied ones via the __drizzle_migrations table.
+echo "Running database migrations..."
+cd /app
+NODE_PATH=/app/migrate/node_modules /app/migrate/node_modules/.bin/drizzle-kit migrate
+
+echo "Starting app..."
+exec node server.js


### PR DESCRIPTION
## What

Fixes the Dockerfile build failure from #46:
\`\`\`
COPY --from=builder /app/drizzle ./drizzle
... failed to calculate checksum: "/app/drizzle": not found
\`\`\`

## Root cause

\`.dockerignore\` excluded the \`drizzle/\` directory (with a comment claiming it was "copied explicitly in the Dockerfile"). But \`COPY . .\` in the builder stage respects \`.dockerignore\`, so \`drizzle/\` was never in the builder context — and the runner stage's explicit \`COPY --from=builder /app/drizzle\` had nothing to copy.

## Fix

- **Remove \`drizzle/\` from \`.dockerignore\`** so it reaches the builder, then the runner stage's explicit \`COPY\` picks it up.
- **Run migrations at container startup** via a small entrypoint script (\`docker-entrypoint.sh\`):
  - \`drizzle-kit\` + deps (\`drizzle-orm\`, \`postgres\`, \`dotenv\`) are installed into \`/app/migrate\` — a separate \`node_modules\` tree, because running \`npm install\` against the standalone build's curated \`/app/node_modules\` prunes it.
  - \`NODE_PATH=/app/migrate/node_modules\` in the entrypoint lets \`drizzle.config.ts\` resolve them.
- **Also copy \`src/db/schema.ts\`** (referenced by \`drizzle.config.ts\`).
- **Drop the optional \`# syntax=docker/dockerfile:1\` directive** — it caused build failures when the buildx frontend image couldn't be pulled.
- **Use \`exec node server.js\`** so the server receives \`SIGTERM\` from \`docker stop\`.

## Verification

Built and smoke-tested locally with a real Postgres container:

\`\`\`
---WEB LOGS---
Running database migrations...
[✓] migrations applied successfully!
Starting app...
   ▲ Next.js 15.5.12
   ✓ Ready in 39ms
---CURL /---
HTTP 200
---DB TABLES---
 public | cards          | table | postgres
 public | decks          | table | postgres
 public | study_sessions | table | postgres
 public | users          | table | postgres
\`\`\`

All 4 tables created, app serving HTTP 200.

## Self-review notes

- The \`drizzle.config.ts\` file is unchanged (dotenv import stays as-is for local dev; in the container, \`NODE_PATH\` makes \`dotenv\` resolvable from \`/app/migrate/node_modules\`).
- The \`◇ injected env (0) from .env.local\` line in the logs is harmless — \`.env.local\` doesn't exist in the container, so dotenv loads 0 vars; \`DATABASE_URL\` comes from the real container env.
- The remaining build warning (\`SecretsUsedInArgOrEnv\` for the build-time \`AUTH_SECRET\` placeholder) is a false positive — that env var is a dummy value used only to satisfy build-time validation, never a real secret.
- After merge, CI will rebuild and push \`ghcr.io/aberiggs/flashcards:latest\`. Then on the homelab: \`docker compose pull && docker compose up -d\` — migrations run automatically on first boot.