### PR TITLE
Fix auth UntrustedHost behind reverse proxy; require all env vars in compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,15 +3,18 @@ services:
     image: postgres:17-alpine
     restart: unless-stopped
     environment:
-      POSTGRES_USER: ${POSTGRES_USER:-postgres}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
-      POSTGRES_DB: ${POSTGRES_DB:-flashcards}
+      # No fallbacks: all DB credentials must be set explicitly in .env, so a
+      # misconfigured first run fails loudly instead of silently creating a
+      # database with default creds.
+      POSTGRES_USER: "${POSTGRES_USER:?POSTGRES_USER is required}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}"
+      POSTGRES_DB: "${POSTGRES_DB:?POSTGRES_DB is required}"
     volumes:
       # Bind-mount Postgres data to a host path you control.
-      # Set POSTGRES_DATA_PATH in .env (e.g. /mnt/raid/flashcards/pgdata).
-      - ${POSTGRES_DATA_PATH:-./pgdata}:/var/lib/postgresql/data
+      # Override POSTGRES_DATA_PATH in .env to place it elsewhere.
+      - ${POSTGRES_DATA_PATH:-/media/IronWolf1/AppData/flashcards/pgdata}:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-flashcards}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -27,9 +30,9 @@ services:
         condition: service_healthy
     environment:
       # Compose: the app reaches Postgres via the `db` service hostname.
-      DATABASE_URL: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@db:5432/${POSTGRES_DB:-flashcards}
+      DATABASE_URL: "postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}"
       AUTH_SECRET: "${AUTH_SECRET:?AUTH_SECRET is required — generate with openssl rand -base64 32}"
-      NEXTAUTH_URL: ${NEXTAUTH_URL:-http://localhost:3000}
+      NEXTAUTH_URL: "${NEXTAUTH_URL:?NEXTAUTH_URL is required}"
     ports:
       # Override the host port via WEB_PORT (e.g. WEB_PORT=8080 → 8080:3000).
       - "${WEB_PORT:-3000}:3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,9 @@ services:
       POSTGRES_DB: "${POSTGRES_DB:?POSTGRES_DB is required}"
     volumes:
       # Bind-mount Postgres data to a host path you control.
-      # Override POSTGRES_DATA_PATH in .env to place it elsewhere.
-      - ${POSTGRES_DATA_PATH:-/media/IronWolf1/AppData/flashcards/pgdata}:/var/lib/postgresql/data
+      # Set POSTGRES_DATA_PATH in .env to an absolute path on a dedicated disk
+      # (e.g. /mnt/raid/flashcards/pgdata). Defaults to ./pgdata.
+      - ${POSTGRES_DATA_PATH:-./pgdata}:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 5s

--- a/docs/build.md
+++ b/docs/build.md
@@ -143,7 +143,7 @@ build toolchain needed on the server.
 
    # Optional overrides (defaults shown):
    # WEB_PORT=3000                           # host port for the web app
-   # POSTGRES_DATA_PATH=/media/IronWolf1/AppData/flashcards/pgdata
+   # POSTGRES_DATA_PATH=./pgdata             # where DB data lives on the host
    EOF
    ```
 
@@ -163,9 +163,10 @@ build toolchain needed on the server.
      these to build its `DATABASE_URL`.
    - **`WEB_PORT`** — host port the app is published on. Default `3000`.
      Change it if you want to run on a different port (e.g. `8080`).
-   - **`POSTGRES_DATA_PATH`** — where Postgres stores its data on the host.
-     Default `/media/IronWolf1/AppData/flashcards/pgdata`. Override to place
-     it elsewhere.
+    - **`POSTGRES_DATA_PATH`** — where Postgres stores its data on the host.
+      Default `./pgdata` (relative to the compose directory). Set to an
+      absolute path on a dedicated disk for control over disk placement, e.g.
+      `/mnt/raid/flashcards/pgdata`.
 
 3. Start it:
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -137,15 +137,19 @@ build toolchain needed on the server.
    cat > .env <<'EOF'
    AUTH_SECRET=paste-the-output-of-openssl-rand-above
    NEXTAUTH_URL=http://flashcards.lan:3000   # public URL of the app
+   POSTGRES_USER=flashcards                  # choose a DB username
+   POSTGRES_PASSWORD=choose-a-strong-db-password
+   POSTGRES_DB=flashcards
 
    # Optional overrides (defaults shown):
    # WEB_PORT=3000                           # host port for the web app
-   # POSTGRES_DATA_PATH=./pgdata             # where DB data lives on the host
-   # POSTGRES_USER=postgres
-   # POSTGRES_PASSWORD=postgres
-   # POSTGRES_DB=flashcards
+   # POSTGRES_DATA_PATH=/media/IronWolf1/AppData/flashcards/pgdata
    EOF
    ```
+
+   All of `AUTH_SECRET`, `NEXTAUTH_URL`, `POSTGRES_USER`, `POSTGRES_PASSWORD`,
+   and `POSTGRES_DB` are **required** — Compose will refuse to start if any is
+   missing, rather than silently falling back to insecure defaults.
 
    What each does:
 
@@ -154,14 +158,14 @@ build toolchain needed on the server.
    - **`NEXTAUTH_URL`** — the public URL of your deployment (used for auth
      redirects). If you're behind a reverse proxy with HTTPS, set this to
      the public-facing URL (e.g. `https://flashcards.yourdomain`).
+   - **`POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DB`** — Postgres
+     credentials. No defaults — you must set all three. The `web` service uses
+     these to build its `DATABASE_URL`.
    - **`WEB_PORT`** — host port the app is published on. Default `3000`.
      Change it if you want to run on a different port (e.g. `8080`).
    - **`POSTGRES_DATA_PATH`** — where Postgres stores its data on the host.
-     Default `./pgdata` (relative to the compose directory). Set to an
-     absolute path on a dedicated disk for control over disk placement, e.g.
-     `/mnt/raid/flashcards/pgdata`.
-   - **`POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DB`** — Postgres
-     credentials. The `web` service uses these to build its `DATABASE_URL`.
+     Default `/media/IronWolf1/AppData/flashcards/pgdata`. Override to place
+     it elsewhere.
 
 3. Start it:
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -7,6 +7,9 @@ import { verifyPassword } from "@/server/queries/auth";
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
   session: { strategy: "jwt" },
+  // Trust the Host header from the reverse proxy so auth redirects use the
+  // public HTTPS URL (NEXTAUTH_URL) instead of being rejected as untrusted.
+  trustHost: true,
   providers: [
     Credentials({
       credentials: {


### PR DESCRIPTION
## What

- **Auth fix**: Add `trustHost: true` to the NextAuth config. Behind a TLS-terminating reverse proxy, Auth.js rejects the Host header as untrusted, breaking login/session endpoints. This tells it to honor the Host header (and `NEXTAUTH_URL`) so auth redirects work over HTTPS.

- **No silent fallbacks for secrets**: Remove the `:-default` fallbacks for `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, and `NEXTAUTH_URL` in `docker-compose.yml`. All are now required via `${VAR:?error}` — a misconfigured first run fails loudly instead of silently provisioning a database with insecure default credentials.

- **Default data path**: `POSTGRES_DATA_PATH` defaults to `/media/IronWolf1/AppData/flashcards/pgdata`.

- **Docs**: Updated `docs/build.md` to list the now-required env vars.

## Why

Encountered `UntrustedHost` error on first homelab deploy behind a reverse proxy. Separately, default DB creds are a footgun if compose runs without a complete `.env`.

## Test plan

- [x] `npm run typecheck` passes
- [ ] CI: lint + tsc pass
- [ ] After merge: `docker compose pull && docker compose up -d` on the server, then log in via the public HTTPS URL