### PR TITLE
Improve AI coding experience: split AGENTS.md into .ai/ rules + skills

### DIFF
--- a/.ai/rules/accessibility.md
+++ b/.ai/rules/accessibility.md
@@ -1,0 +1,7 @@
+# Accessibility
+
+- All icon-only buttons must have `aria-label`.
+- Decorative Lucide icons: `<Icon className="w-4 h-4" aria-hidden />`.
+- Non-`<button>` clickable elements need `role="button"`, `tabIndex={0}`, and an
+  `onKeyDown` handler.
+- Interactive elements: include `focus:outline-none focus:ring-2 focus:ring-[--accent-primary]`.

--- a/.ai/rules/auth.md
+++ b/.ai/rules/auth.md
@@ -1,0 +1,18 @@
+# Auth
+
+- Auth is configured in `src/auth.ts` (NextAuth v5) using the **Credentials**
+  provider — email + password validated against the `users` table, with passwords
+  hashed via `bcryptjs` (cost 12). No OAuth, no external provider accounts.
+- Session strategy is **JWT** (signed with `AUTH_SECRET`) — no DB session table.
+  The `users` table is the only auth table.
+- First-user setup: when the `users` table is empty, the home page shows a
+  registration form. Once the first user is created, registration closes
+  automatically (`/api/auth/register` returns 403 when any user exists).
+- App tables (`decks`, `cards`, `studySessions`) use `bigint` serial PKs for compact
+  URLs; their `userId` foreign key is `text` referencing `users.id`.
+- `src/middleware.ts` gates protected routes by checking `req.auth` from the NextAuth
+  middleware wrapper.
+- The `(protected)/` route group's `layout.tsx` handles the auth gate client-side
+  via `useSession()` — all child pages can assume the user is authenticated.
+- Required env vars: `DATABASE_URL`, `AUTH_SECRET`, `NEXTAUTH_URL`. That's it —
+  no OAuth client IDs or secrets.

--- a/.ai/rules/backend.md
+++ b/.ai/rules/backend.md
@@ -1,0 +1,16 @@
+# Backend (Drizzle + Route Handlers)
+
+- Scope every query/mutation to the authenticated user: call `getAuthUserId()` or
+  `requireAuthUserId()` from `src/server/auth.ts`.
+  - **Reads**: return `null` or `[]` when unauthenticated.
+  - **Writes**: throw `new Error("Not authenticated")` when unauthenticated.
+- Ownership checks: throw `new Error("<Entity> not found")` if the record doesn't
+  belong to the caller.
+- Keep query logic in `src/server/queries/*.ts`. Keep Route Handlers in
+  `src/app/api/**/route.ts` thin — they parse the request, call a query function,
+  and return JSON.
+- Use Drizzle's query builder (`eq`, `and`, `lt`, `sql`, etc.) — avoid raw SQL
+  strings unless the builder can't express the query.
+- Foreign keys use `ON DELETE CASCADE` where children should be removed with their
+  parent (e.g. cards when a deck is deleted).
+- Never return raw secrets from API routes.

--- a/.ai/rules/code-style.md
+++ b/.ai/rules/code-style.md
@@ -1,0 +1,41 @@
+# Code Style
+
+## Imports
+
+```ts
+// 1. React (if needed explicitly)
+import { useState, useCallback } from "react";
+// 2. Third-party packages
+import { useQuery } from "@tanstack/react-query";
+// 3. Internal — alias imports (@/)
+import { Modal } from "@/components/ui/Modal";
+import { useDecks } from "@/lib/hooks";
+```
+
+## Components
+
+- Every client component starts with `'use client';` (single quotes) on line 1.
+- Use **named exports** everywhere. Default exports are reserved for Next.js page and
+  layout files (`export default function Page() { … }`).
+- Define props interfaces directly above the component:
+
+  ```ts
+  interface CardProps {
+    title: string;
+    children: ReactNode;
+  }
+
+  export function Card({ title, children }: CardProps) { … }
+  ```
+
+- Use `ReactNode` for `children`, not `JSX.Element` or `React.FC`.
+
+## Naming
+
+| Thing                        | Convention                  |
+| ---------------------------- | --------------------------- |
+| Components / files           | `PascalCase`                |
+| Route handler files          | `route.ts` (Next.js convention) |
+| Variables / functions        | `camelCase`                 |
+| Types / interfaces           | `PascalCase` (no `I` prefix) |
+| Constants (module-level)     | `SCREAMING_SNAKE_CASE` + `as const` |

--- a/.ai/rules/do-not.md
+++ b/.ai/rules/do-not.md
@@ -1,0 +1,6 @@
+# Do Not
+
+- Add a global state library (Zustand, Redux, Jotai) without discussion.
+- Add a test framework ad-hoc — if tests are needed, plan the framework choice first.
+- Use `console.log` in committed code; use `console.error` only in genuine error paths.
+- Add Prettier or change the ESLint config without updating this file.

--- a/.ai/rules/error-handling.md
+++ b/.ai/rules/error-handling.md
@@ -1,0 +1,13 @@
+# Error Handling (Client)
+
+```ts
+try {
+  await doSomething();
+} catch (err) {
+  setError(err instanceof Error ? err.message : "An unexpected error occurred");
+}
+```
+
+- Use `void expression()` to intentionally discard a promise in event handlers
+  (e.g., `void signOut()`).
+- Never swallow errors silently.

--- a/.ai/rules/git-workflow.md
+++ b/.ai/rules/git-workflow.md
@@ -1,0 +1,10 @@
+# Git workflow
+
+All changes should be in the form of pull requests opened in **draft** mode,
+based off the `main` branch, unless the user explicitly says otherwise.
+
+- Branch from `main` (or rebase onto it before pushing if `main` has moved).
+- Open the PR as a draft. Mark it ready for review only when the user asks.
+- Do not push directly to `main`, and do not merge a PR without explicit user
+  approval.
+- Keep commits focused; stage only the intended files and never commit secrets.

--- a/.ai/rules/iterating-on-ai-docs.md
+++ b/.ai/rules/iterating-on-ai-docs.md
@@ -1,0 +1,40 @@
+# Iterating on AI docs
+
+The files under `.ai/` are living docs. When the agent (or the developer) runs
+into a rough edge, an undocumented convention, or a clarification during work,
+update the relevant file so the next session doesn't hit the same problem.
+
+## When to update
+
+- You discovered a convention that wasn't written down anywhere.
+- A rule in `.ai/rules/` contradicted what you actually had to do.
+- A skill in `.ai/skills/` was missing a step you had to figure out.
+- A tool command, env var, or build step changed.
+- You had to ask the user for clarification on something that should be
+  documented.
+
+## Where to update
+
+| Change                                                | File                                       |
+| ----------------------------------------------------- | ------------------------------------------ |
+| Always-true convention (style, TS, auth, backend)    | `.ai/rules/<topic>.md` (edit or create)    |
+| Task-specific workflow (how to do X end-to-end)       | `.ai/skills/<name>/SKILL.md` (edit/create) |
+| Stack, commands, CI                                    | `.ai/rules/stack-and-commands.md`         |
+| Project layout                                          | `.ai/rules/project-layout.md`             |
+| User-visible feature change                            | `docs/features.md` (per `keeping-docs-current.md`) |
+| Dev setup / env / deployment change                    | `docs/build.md`                            |
+
+## How to update
+
+- Keep entries short and scannable — bullets, not prose.
+- Don't duplicate: if a rule already lives in one file, link to it instead of
+  restating it.
+- If you create a new rule file, add it to the index in `AGENTS.md`.
+- If you create a new skill, add it to `opencode.json` `skills.paths` is already
+  wired to scan `.ai/skills/` — just make a new folder with `SKILL.md`.
+
+## Do not
+
+- Don't reformat or reorganize these files for style alone. Only change them when
+  you have something concrete to add or fix.
+- Don't delete a rule without confirming with the user.

--- a/.ai/rules/keeping-docs-current.md
+++ b/.ai/rules/keeping-docs-current.md
@@ -1,0 +1,13 @@
+# Keeping Docs Current
+
+After completing any feature work or making meaningful changes, update `docs/features.md`:
+
+- **Keep current capabilities current**: add or revise user-visible functionality in
+  the appropriate section.
+- **Keep descriptions honest**: write feature notes as user-visible capabilities, not
+  implementation details.
+- **Don't over-document**: trivial bug fixes and refactors don't need feature doc updates.
+  New user-facing features and significant UX changes do.
+
+Also update `docs/build.md` if you change the dev setup, environment variables,
+deployment process, or add new tooling.

--- a/.ai/rules/project-layout.md
+++ b/.ai/rules/project-layout.md
@@ -1,0 +1,53 @@
+# Project Layout
+
+```
+src/
+  app/
+    (protected)/          # Auth-gated route group — all pages are 'use client'
+    api/                  # Next.js Route Handlers (REST endpoints)
+      api/auth/[...nextauth]/route.ts   # Auth.js handler
+      api/decks/...       # Deck + card + study + stats endpoints
+      api/stats/...       # Dashboard stats endpoints
+      api/search/         # Search endpoint
+      api/import/         # Bulk import endpoint
+    AuthSessionProvider.tsx  # Client-side next-auth SessionProvider
+    QueryProvider.tsx        # TanStack Query client provider
+    globals.css           # Tailwind v4 @theme + CSS custom properties
+    layout.tsx            # Root layout (providers)
+    page.tsx              # Landing / dashboard
+  auth.ts                 # NextAuth config (providers, adapter, callbacks)
+  middleware.ts           # Route protection (auth-gated middleware)
+  components/
+    features/             # Domain-specific components (dashboard/, decks/)
+    layout/               # AppHeader, Footer, SearchBar
+    theme/                # ThemeProvider, ThemeToggle
+    ui/                   # Generic primitives (Card, Modal, PageLoader, …)
+  db/
+    schema.ts             # Drizzle schema (source of truth for all tables)
+    index.ts              # Postgres connection + Drizzle instance
+  lib/
+    sm2.ts                # SM-2 spaced-repetition algorithm (pure logic)
+    limits.ts             # Resource cap constants
+    hooks.ts              # TanStack Query hooks (useDecks, useCards, etc.)
+    api.ts                # Typed fetch client for the REST API
+    parseDeck.ts          # Import file parsing (CSV/TXT/JSON)
+    exportDeck.ts         # Deck export (CSV/JSON)
+    memoryStage.ts        # Memory stage classification
+  server/
+    auth.ts               # getAuthUserId / requireAuthUserId helpers
+    api.ts                # Route Handler response helpers
+    queries/
+      decks.ts            # Deck CRUD + stats aggregation
+      cards.ts            # Card CRUD + SM-2 review recording
+      sessions.ts         # Study session lifecycle
+      stats.ts            # Dashboard / deck / gamification / activity stats
+      search.ts           # ILIKE search
+      import.ts           # Bulk deck import
+  types/
+    next-auth.d.ts        # Session.user.id type augmentation
+
+drizzle/                  # Generated migration SQL files (committed)
+drizzle.config.ts         # Drizzle Kit configuration
+Dockerfile                # Multi-stage Next.js standalone build
+docker-compose.yml        # Next.js + Postgres self-host deployment
+```

--- a/.ai/rules/stack-and-commands.md
+++ b/.ai/rules/stack-and-commands.md
@@ -1,0 +1,42 @@
+# Stack
+
+| Layer      | Technology                                              |
+| ---------- | ------------------------------------------------------- |
+| Frontend   | Next.js 15 (App Router, Turbopack, standalone output), React 19, Tailwind v4 |
+| Backend    | Postgres + Drizzle ORM, exposed via Next.js Route Handlers under `src/app/api/` |
+| Auth       | Auth.js (NextAuth v5) with Credentials provider (email + password, JWT sessions) |
+| Charts     | Recharts                                                |
+| Icons      | Lucide React                                            |
+| Data       | TanStack Query (request/response + refetch — no realtime) |
+| Deployment | Docker Compose (Next.js + Postgres) — self-hosted, no cloud dependencies |
+
+## Commands
+
+```bash
+# Start Next.js dev server (Turbopack)
+npm run dev
+
+# Lint (ESLint with next/core-web-vitals + next/typescript)
+npm run lint
+
+# Type-check without emitting (run this before committing)
+npm run typecheck
+
+# Drizzle migrations
+npm run db:generate   # generate a migration from schema changes
+npm run db:migrate    # apply pending migrations
+npm run db:push       # push schema directly to DB (dev only)
+npm run db:studio     # open Drizzle Studio (DB browser)
+
+# Production build (Next.js standalone output)
+npm run build
+```
+
+> **No test runner exists.** There are no Jest, Vitest, Playwright, or other test
+> frameworks in this project. CI runs `npm run lint` and `npx tsc --noEmit` only.
+
+## CI / CD
+
+- **Every push/PR**: `npm ci` → `npm run lint` → `npx tsc --noEmit`
+- **Docker Compose** is the canonical self-host deployment (`docker compose up`).
+- No codegen step needed — Drizzle types are inferred from `src/db/schema.ts`.

--- a/.ai/rules/state-management.md
+++ b/.ai/rules/state-management.md
@@ -1,0 +1,10 @@
+# State Management
+
+- No global state library. Use React built-ins: `useState`, `useEffect`, `useRef`,
+  `useCallback`.
+- TanStack Query provides caching, refetch, and loading states. `useMutation` /
+  `useQuery` hooks in `src/lib/hooks.ts` are the data layer — invalidate affected
+  query keys in mutation `onSuccess` callbacks to keep the UI fresh.
+- When you need a stable snapshot of data (e.g., during a study session), copy
+  query results into local state at session start to prevent mid-session re-sorting
+  from refetches.

--- a/.ai/rules/styling.md
+++ b/.ai/rules/styling.md
@@ -1,0 +1,9 @@
+# Styling (Tailwind v4)
+
+- **No `tailwind.config.*`** — configuration lives in `globals.css` via `@theme inline`.
+- Use the CSS custom property tokens (`--surface-primary`, `--text-secondary`,
+  `--accent-primary`, etc.) rather than raw hex values.
+- Use `style={{ … }}` only when Tailwind can't express the value (CSS variables,
+  `color-mix()`, dynamic `calc()` expressions).
+- Conditional classes: template literals or a helper — avoid third-party `clsx` unless
+  already present.

--- a/.ai/rules/typescript.md
+++ b/.ai/rules/typescript.md
@@ -1,0 +1,10 @@
+# TypeScript
+
+- **Strict mode** is enabled in `tsconfig.json`.
+- Root target: `ES2017`.
+- **Path alias**: `@/*` → `./src/*`. Use `@/` for all intra-`src/` imports.
+- Never use `any`; prefer `unknown` + type guards when the shape is truly unknown.
+- Avoid type assertions (`as Foo`) unless bridging external API responses that are
+  already validated.
+- `interface` for object shapes; `type` for unions, intersections, and aliases.
+- Do **not** prefix interface names with `I`.

--- a/.ai/skills/adding-backend-endpoint/SKILL.md
+++ b/.ai/skills/adding-backend-endpoint/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: adding-backend-endpoint
+description: Use when adding or modifying a backend API endpoint, server query, or mutation in the flashcards app. Covers the Drizzle query layer under src/server/queries/, thin Route Handlers under src/app/api/, authenticated scoping with getAuthUserId/requireAuthUserId, and ownership checks. Do not use for frontend-only work.
+---
+
+# Adding a backend endpoint
+
+The flashcards backend is Postgres + Drizzle ORM exposed via Next.js Route
+Handlers. The flow for any new read or write is:
+
+## 1. Query layer (`src/server/queries/*.ts`)
+
+Put domain logic here. Each function:
+
+- Calls `getAuthUserId()` (reads may return `null`/`[]` when unauthenticated) or
+  `requireAuthUserId()` (writes throw `new Error("Not authenticated")`) from
+  `src/server/auth.ts`.
+- Scopes every Drizzle query to the authenticated user's `userId`.
+- For mutations on owned records (decks, cards), checks ownership and throws
+  `new Error("<Entity> not found")` if the record doesn't belong to the caller.
+- Uses Drizzle's query builder (`eq`, `and`, `lt`, `sql`, …) — avoid raw SQL unless
+  the builder can't express the query.
+- Never returns raw secrets.
+
+## 2. Route Handler (`src/app/api/**/route.ts`)
+
+Keep it thin:
+
+- Parse the request (params, body).
+- Call the query function.
+- Return JSON using the helpers in `src/server/api.ts`.
+
+Do not put domain logic in the Route Handler.
+
+## 3. Client hook (`src/lib/hooks.ts`)
+
+If the endpoint is consumed by the UI, add a TanStack Query hook (`useQuery` for
+reads, `useMutation` for writes) in `src/lib/hooks.ts`. For mutations, invalidate
+affected query keys in `onSuccess` so the UI refreshes.
+
+## 4. Schema changes
+
+If the endpoint needs a new column or table:
+
+1. Edit `src/db/schema.ts`.
+2. `npm run db:generate` to create a migration in `drizzle/`.
+3. `npm run db:migrate` to apply it.
+4. Commit the new `drizzle/*.sql` file.
+
+Foreign keys use `ON DELETE CASCADE` where children should be removed with their
+parent (e.g. cards when a deck is deleted).
+
+## 5. Verify
+
+Run `npm run lint` and `npm run typecheck` before committing. CI runs the same
+two checks.

--- a/.ai/skills/building-client-component/SKILL.md
+++ b/.ai/skills/building-client-component/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: building-client-component
+description: Use when creating or editing a React client component in the flashcards app. Covers 'use client' directive, named exports, props interfaces above the component, ReactNode children, Tailwind v4 tokens, and accessibility rules. Do not use for server components or backend work.
+---
+
+# Building a client component
+
+All pages in the `(protected)/` route group are `'use client'`. Most components
+in `src/components/` are client components too.
+
+## Required conventions
+
+- Line 1 of the file is `'use client';` (single quotes).
+- Use **named exports**. Default exports are reserved for Next.js page and layout
+  files (`export default function Page()`).
+- Define props interfaces directly above the component:
+
+  ```ts
+  interface CardProps {
+    title: string;
+    children: ReactNode;
+  }
+
+  export function Card({ title, children }: CardProps) { … }
+  ```
+
+- Use `ReactNode` for `children`, not `JSX.Element` or `React.FC`.
+- Files and components are `PascalCase`. Variables/functions are `camelCase`.
+
+## Imports
+
+```ts
+// 1. React (if needed explicitly)
+import { useState, useCallback } from "react";
+// 2. Third-party packages
+import { useQuery } from "@tanstack/react-query";
+// 3. Internal — alias imports (@/)
+import { Modal } from "@/components/ui/Modal";
+import { useDecks } from "@/lib/hooks";
+```
+
+## Styling (Tailwind v4)
+
+- No `tailwind.config.*` — config lives in `src/app/globals.css` via `@theme inline`.
+- Use the CSS custom property tokens (`--surface-primary`, `--text-secondary`,
+  `--accent-primary`, …) rather than raw hex values.
+- Use `style={{ … }}` only when Tailwind can't express the value (CSS variables,
+  `color-mix()`, dynamic `calc()`).
+- Conditional classes: template literals or a helper — avoid third-party `clsx`
+  unless already present.
+
+## Accessibility
+
+- All icon-only buttons must have `aria-label`.
+- Decorative Lucide icons: `<Icon className="w-4 h-4" aria-hidden />`.
+- Non-`<button>` clickable elements need `role="button"`, `tabIndex={0}`, and an
+  `onKeyDown` handler.
+- Interactive elements: include
+  `focus:outline-none focus:ring-2 focus:ring-[--accent-primary]`.
+
+## Data
+
+- Use TanStack Query hooks from `src/lib/hooks.ts` for server state.
+- For a stable snapshot during a study session, copy query results into local
+  state at session start to prevent mid-session re-sorting from refetches.
+- No global state library. Use React built-ins (`useState`, `useEffect`,
+  `useRef`, `useCallback`).
+
+## Error handling
+
+```ts
+try {
+  await doSomething();
+} catch (err) {
+  setError(err instanceof Error ? err.message : "An unexpected error occurred");
+}
+```
+
+- Use `void expression()` to intentionally discard a promise in event handlers
+  (e.g., `void signOut()`).
+- Never swallow errors silently.

--- a/.ai/skills/completing-task/SKILL.md
+++ b/.ai/skills/completing-task/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: completing-task
+description: Use when finishing any software engineering task in the flashcards repo. Covers running lint and typecheck, updating docs/features.md and docs/build.md for user-visible or build/deploy changes, and the no-commit-unless-asked rule.
+---
+
+# Completing a task
+
+Run these before considering a task done:
+
+## 1. Lint and type-check
+
+```bash
+npm run lint
+npm run typecheck
+```
+
+CI runs exactly these two checks on every push/PR. No test runner exists in this
+project — do not add one ad-hoc. If tests are needed, plan the framework choice
+first.
+
+If you can't find the correct command, ask the user and suggest writing it into
+`AGENTS.md` so future sessions know.
+
+## 2. Update docs
+
+After **user-visible** feature work or significant UX changes, update
+`docs/features.md`:
+
+- Add or revise user-visible functionality in the appropriate section.
+- Write feature notes as user-visible capabilities, not implementation details.
+- Trivial bug fixes and refactors don't need feature doc updates.
+
+After changes to the **dev setup, environment variables, deployment process, or
+tooling**, update `docs/build.md`.
+
+## 3. Commit
+
+Do **not** commit unless the user explicitly asks. If asked, stage only the
+intended files and never commit secrets.
+
+## 4. Iterate on these AI docs
+
+If you ran into a rough edge, an undocumented convention, or a clarification
+during the work, update the relevant file under `.ai/rules/` or `.ai/skills/` so
+the next session doesn't hit the same problem. See `.ai/rules/iterating-on-ai-docs.md`.

--- a/.ai/skills/schema-migration/SKILL.md
+++ b/.ai/skills/schema-migration/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: schema-migration
+description: Use when changing the database schema in src/db/schema.ts. Covers the Drizzle generate → migrate → commit workflow, ON DELETE CASCADE conventions, bigint PKs, and the userId text foreign key. Do not use for query-only changes.
+---
+
+# Schema migration
+
+The source of truth for all tables is `src/db/schema.ts`. Drizzle types are
+inferred from it — no codegen step is needed.
+
+## Workflow
+
+1. Edit `src/db/schema.ts`.
+2. Generate a migration from the change:
+
+   ```bash
+   npm run db:generate
+   ```
+
+   This creates a new `drizzle/*.sql` file.
+
+3. Apply pending migrations:
+
+   ```bash
+   npm run db:migrate
+   ```
+
+   For dev-only rapid iteration you can skip migration files with
+   `npm run db:push`, but prefer the generate/migrate flow for anything you'll
+   commit.
+
+4. Commit the new `drizzle/*.sql` file alongside the schema change.
+
+## Conventions
+
+- App tables (`decks`, `cards`, `studySessions`) use `bigint` serial PKs for
+  compact URLs.
+- Their `userId` foreign key is `text` referencing `users.id`.
+- Foreign keys use `ON DELETE CASCADE` where children should be removed with
+  their parent (e.g. cards when a deck is deleted).
+- The `users` table is the only auth table (JWT sessions, no DB session table).
+
+## Verify
+
+After a schema change, run `npm run lint` and `npm run typecheck` before
+committing. CI runs the same two checks.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,14 @@
+# GitHub Copilot Instructions
+
+This project's detailed agent guidelines live in [`AGENTS.md`](../../AGENTS.md)
+and the `.ai/` directory. Read `AGENTS.md` first — it is a short index that
+points into:
+
+- `.ai/rules/*.md` — always-true conventions (stack, layout, TypeScript, code
+  style, backend, styling, accessibility, auth, state management, etc.).
+- `.ai/skills/*/SKILL.md` — task-specific end-to-end recipes (adding a backend
+  endpoint, building a client component, schema migration, completing a task).
+
+Load only the rule or skill relevant to the current task instead of holding
+all of them in context. Keep `.ai/` current when you run into undocumented
+conventions (see `.ai/rules/iterating-on-ai-docs.md`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,274 +1,72 @@
 # Agent Guidelines for `flashcards`
 
-A Next.js 15 + Convex full-stack flashcard app with SM-2 spaced repetition, AI card
-generation, and OAuth authentication (GitHub + Google).
+A Next.js 15 + Postgres + Drizzle full-stack flashcard app with SM-2 spaced
+repetition, Auth.js (Credentials provider) authentication, and Docker Compose
+self-hosted deployment.
+
+The detailed rules and skills live under `.ai/` so this file stays a short
+index. Load only the rule or skill you need for the current task instead of
+holding all of it in context.
 
 ---
 
-## Stack
+## Rules (always-true conventions)
 
-| Layer      | Technology                                              |
-| ---------- | ------------------------------------------------------- |
-| Frontend   | Next.js 15 (App Router, Turbopack, standalone output), React 19, Tailwind v4 |
-| Backend    | Postgres + Drizzle ORM, exposed via Next.js Route Handlers under `src/app/api/` |
-| Auth       | Auth.js (NextAuth v5) with Credentials provider (email + password, JWT sessions) |
-| Charts     | Recharts                                                |
-| Icons      | Lucide React                                            |
-| Data       | TanStack Query (request/response + refetch — no realtime) |
-| Deployment | Docker Compose (Next.js + Postgres) — self-hosted, no cloud dependencies |
+Read the ones relevant to what you're touching.
 
----
+| File | Summary |
+| --- | --- |
+| [`.ai/rules/stack-and-commands.md`](.ai/rules/stack-and-commands.md) | Stack table, npm scripts, CI pipeline. |
+| [`.ai/rules/project-layout.md`](.ai/rules/project-layout.md) | Directory map of `src/`, `drizzle/`, Docker files. |
+| [`.ai/rules/typescript.md`](.ai/rules/typescript.md) | Strict TS, `@/*` alias, `interface` vs `type`, no `I` prefix. |
+| [`.ai/rules/code-style.md`](.ai/rules/code-style.md) | Import order, `'use client'`, named exports, props interfaces, naming table. |
+| [`.ai/rules/backend.md`](.ai/rules/backend.md) | Drizzle query layer, thin Route Handlers, auth scoping, ownership checks. |
+| [`.ai/rules/error-handling.md`](.ai/rules/error-handling.md) | Client try/catch pattern, `void expression()`, no silent swallows. |
+| [`.ai/rules/styling.md`](.ai/rules/styling.md) | Tailwind v4 `@theme`, CSS variable tokens, when to use `style=`. |
+| [`.ai/rules/accessibility.md`](.ai/rules/accessibility.md) | aria-labels, decorative icons, keyboard handlers, focus rings. |
+| [`.ai/rules/state-management.md`](.ai/rules/state-management.md) | React built-ins + TanStack Query, snapshot-into-local-state for sessions. |
+| [`.ai/rules/git-workflow.md`](.ai/rules/git-workflow.md) | All changes via draft PRs off `main`, unless the user says otherwise. |
+| [`.ai/rules/auth.md`](.ai/rules/auth.md) | NextAuth v5 Credentials provider, JWT sessions, first-user setup, env vars. |
+| [`.ai/rules/keeping-docs-current.md`](.ai/rules/keeping-docs-current.md) | When to update `docs/features.md` and `docs/build.md`. |
+| [`.ai/rules/do-not.md`](.ai/rules/do-not.md) | Global state libs, test frameworks, `console.log`, Prettier/ESLint changes. |
+| [`.ai/rules/iterating-on-ai-docs.md`](.ai/rules/iterating-on-ai-docs.md) | When and how to update these AI docs as we learn. **Read this one first.** |
 
-## Commands
+## Skills (task-specific workflows)
 
-```bash
-# Start Next.js dev server (Turbopack)
-npm run dev
+Each skill is a short end-to-end recipe. Load it when the task matches its
+description.
 
-# Lint (ESLint with next/core-web-vitals + next/typescript)
-npm run lint
+| Skill | Summary |
+| --- | --- |
+| [`.ai/skills/adding-backend-endpoint/SKILL.md`](.ai/skills/adding-backend-endpoint/SKILL.md) | Add a Drizzle query + thin Route Handler + client hook, auth-scoped. |
+| [`.ai/skills/building-client-component/SKILL.md`](.ai/skills/building-client-component/SKILL.md) | Create a `'use client'` component: props, imports, Tailwind tokens, a11y. |
+| [`.ai/skills/schema-migration/SKILL.md`](.ai/skills/schema-migration/SKILL.md) | Edit `schema.ts` → `db:generate` → `db:migrate` → commit the SQL file. |
+| [`.ai/skills/completing-task/SKILL.md`](.ai/skills/completing-task/SKILL.md) | Run lint + typecheck, update docs, don't commit unless asked. |
 
-# Type-check without emitting (run this before committing)
-npm run typecheck
+## Quick reference
 
-# Drizzle migrations
-npm run db:generate   # generate a migration from schema changes
-npm run db:migrate    # apply pending migrations
-npm run db:push       # push schema directly to DB (dev only)
-npm run db:studio     # open Drizzle Studio (DB browser)
+- **Dev**: `npm run dev`
+- **Lint**: `npm run lint`
+- **Type-check**: `npm run typecheck`
+- **DB migrate**: `npm run db:generate` then `npm run db:migrate`
+- **Build**: `npm run build`
+- **No test runner** — CI runs `npm run lint` and `npx tsc --noEmit` only.
 
-# Production build (Next.js standalone output)
-npm run build
-```
+## Keep these docs current
 
-> **No test runner exists.** There are no Jest, Vitest, Playwright, or other test
-> frameworks in this project. CI runs `npm run lint` and `npx tsc --noEmit` only.
+Every time you (the agent) run into a convention that wasn't written down, a
+rule that contradicted reality, or a clarification you had to ask the user for,
+update the relevant file under `.ai/rules/` or `.ai/skills/`. Full guidance in
+[`.ai/rules/iterating-on-ai-docs.md`](.ai/rules/iterating-on-ai-docs.md).
 
----
+## Cross-tool compatibility
 
-## CI / CD
+This `.ai/` layout is the source of truth. Other AI tools read thin pointers
+from it rather than maintaining separate copies:
 
-- **Every push/PR**: `npm ci` → `npm run lint` → `npx tsc --noEmit`
-- **Docker Compose** is the canonical self-host deployment (`docker compose up`).
-- No codegen step needed — Drizzle types are inferred from `src/db/schema.ts`.
+- **opencode** — `opencode.json` registers `.ai/skills/` as a skills path.
+- **Claude Code** — `CLAUDE.md` `@`-imports the rules and skills below.
+- **GitHub Copilot** — `.github/copilot-instructions.md` points here.
 
----
-
-## Project Layout
-
-```
-src/
-  app/
-    (protected)/          # Auth-gated route group — all pages are 'use client'
-    api/                  # Next.js Route Handlers (REST endpoints)
-      api/auth/[...nextauth]/route.ts   # Auth.js handler
-      api/decks/...       # Deck + card + study + stats endpoints
-      api/stats/...       # Dashboard stats endpoints
-      api/search/         # Search endpoint
-      api/import/         # Bulk import endpoint
-    AuthSessionProvider.tsx  # Client-side next-auth SessionProvider
-    QueryProvider.tsx        # TanStack Query client provider
-    globals.css           # Tailwind v4 @theme + CSS custom properties
-    layout.tsx            # Root layout (providers)
-    page.tsx              # Landing / dashboard
-  auth.ts                 # NextAuth config (providers, adapter, callbacks)
-  middleware.ts           # Route protection (auth-gated middleware)
-  components/
-    features/             # Domain-specific components (dashboard/, decks/)
-    layout/               # AppHeader, Footer, SearchBar
-    theme/                # ThemeProvider, ThemeToggle
-    ui/                   # Generic primitives (Card, Modal, PageLoader, …)
-  db/
-    schema.ts             # Drizzle schema (source of truth for all tables)
-    index.ts              # Postgres connection + Drizzle instance
-  lib/
-    sm2.ts                # SM-2 spaced-repetition algorithm (pure logic)
-    limits.ts             # Resource cap constants
-    hooks.ts              # TanStack Query hooks (useDecks, useCards, etc.)
-    api.ts                # Typed fetch client for the REST API
-    parseDeck.ts          # Import file parsing (CSV/TXT/JSON)
-    exportDeck.ts         # Deck export (CSV/JSON)
-    memoryStage.ts        # Memory stage classification
-  server/
-    auth.ts               # getAuthUserId / requireAuthUserId helpers
-    api.ts                # Route Handler response helpers
-    queries/
-      decks.ts            # Deck CRUD + stats aggregation
-      cards.ts            # Card CRUD + SM-2 review recording
-      sessions.ts         # Study session lifecycle
-      stats.ts            # Dashboard / deck / gamification / activity stats
-      search.ts           # ILIKE search
-      import.ts           # Bulk deck import
-  types/
-    next-auth.d.ts        # Session.user.id type augmentation
-
-drizzle/                  # Generated migration SQL files (committed)
-drizzle.config.ts         # Drizzle Kit configuration
-Dockerfile                # Multi-stage Next.js standalone build
-docker-compose.yml        # Next.js + Postgres self-host deployment
-```
-
----
-
-## TypeScript
-
-- **Strict mode** is enabled in `tsconfig.json`.
-- Root target: `ES2017`.
-- **Path alias**: `@/*` → `./src/*`. Use `@/` for all intra-`src/` imports.
-- Never use `any`; prefer `unknown` + type guards when the shape is truly unknown.
-- Avoid type assertions (`as Foo`) unless bridging external API responses that are
-  already validated.
-- `interface` for object shapes; `type` for unions, intersections, and aliases.
-- Do **not** prefix interface names with `I`.
-
----
-
-## Code Style
-
-### Imports
-
-```ts
-// 1. React (if needed explicitly)
-import { useState, useCallback } from "react";
-// 2. Third-party packages
-import { useQuery } from "@tanstack/react-query";
-// 3. Internal — alias imports (@/)
-import { Modal } from "@/components/ui/Modal";
-import { useDecks } from "@/lib/hooks";
-```
-
-### Components
-
-- Every client component starts with `'use client';` (single quotes) on line 1.
-- Use **named exports** everywhere. Default exports are reserved for Next.js page and
-  layout files (`export default function Page() { … }`).
-- Define props interfaces directly above the component:
-
-  ```ts
-  interface CardProps {
-    title: string;
-    children: ReactNode;
-  }
-
-  export function Card({ title, children }: CardProps) { … }
-  ```
-
-- Use `ReactNode` for `children`, not `JSX.Element` or `React.FC`.
-
-### Naming
-
-| Thing                        | Convention                  |
-| ---------------------------- | --------------------------- |
-| Components / files           | `PascalCase`                |
-| Route handler files          | `route.ts` (Next.js convention) |
-| Variables / functions        | `camelCase`                 |
-| Types / interfaces           | `PascalCase` (no `I` prefix) |
-| Constants (module-level)     | `SCREAMING_SNAKE_CASE` + `as const` |
-
-### Backend (Drizzle + Route Handlers)
-
-- Scope every query/mutation to the authenticated user: call `getAuthUserId()` or
-  `requireAuthUserId()` from `src/server/auth.ts`.
-  - **Reads**: return `null` or `[]` when unauthenticated.
-  - **Writes**: throw `new Error("Not authenticated")` when unauthenticated.
-- Ownership checks: throw `new Error("<Entity> not found")` if the record doesn't
-  belong to the caller.
-- Keep query logic in `src/server/queries/*.ts`. Keep Route Handlers in
-  `src/app/api/**/route.ts` thin — they parse the request, call a query function,
-  and return JSON.
-- Use Drizzle's query builder (`eq`, `and`, `lt`, `sql`, etc.) — avoid raw SQL
-  strings unless the builder can't express the query.
-- Foreign keys use `ON DELETE CASCADE` where children should be removed with their
-  parent (e.g. cards when a deck is deleted).
-- Never return raw secrets from API routes.
-
-### Error Handling (Client)
-
-```ts
-try {
-  await doSomething();
-} catch (err) {
-  setError(err instanceof Error ? err.message : "An unexpected error occurred");
-}
-```
-
-- Use `void expression()` to intentionally discard a promise in event handlers
-  (e.g., `void signOut()`).
-- Never swallow errors silently.
-
-### Styling (Tailwind v4)
-
-- **No `tailwind.config.*`** — configuration lives in `globals.css` via `@theme inline`.
-- Use the CSS custom property tokens (`--surface-primary`, `--text-secondary`,
-  `--accent-primary`, etc.) rather than raw hex values.
-- Use `style={{ … }}` only when Tailwind can't express the value (CSS variables,
-  `color-mix()`, dynamic `calc()` expressions).
-- Conditional classes: template literals or a helper — avoid third-party `clsx` unless
-  already present.
-
-### Accessibility
-
-- All icon-only buttons must have `aria-label`.
-- Decorative Lucide icons: `<Icon className="w-4 h-4" aria-hidden />`.
-- Non-`<button>` clickable elements need `role="button"`, `tabIndex={0}`, and an
-  `onKeyDown` handler.
-- Interactive elements: include `focus:outline-none focus:ring-2 focus:ring-[--accent-primary]`.
-
----
-
-## State Management
-
-- No global state library. Use React built-ins: `useState`, `useEffect`, `useRef`,
-  `useCallback`.
-- TanStack Query provides caching, refetch, and loading states. `useMutation` /
-  `useQuery` hooks in `src/lib/hooks.ts` are the data layer — invalidate affected
-  query keys in mutation `onSuccess` callbacks to keep the UI fresh.
-- When you need a stable snapshot of data (e.g., during a study session), copy
-  query results into local state at session start to prevent mid-session re-sorting
-  from refetches.
-
----
-
-## Auth
-
-- Auth is configured in `src/auth.ts` (NextAuth v5) using the **Credentials**
-  provider — email + password validated against the `users` table, with passwords
-  hashed via `bcryptjs` (cost 12). No OAuth, no external provider accounts.
-- Session strategy is **JWT** (signed with `AUTH_SECRET`) — no DB session table.
-  The `users` table is the only auth table.
-- First-user setup: when the `users` table is empty, the home page shows a
-  registration form. Once the first user is created, registration closes
-  automatically (`/api/auth/register` returns 403 when any user exists).
-- App tables (`decks`, `cards`, `studySessions`) use `bigint` serial PKs for compact
-  URLs; their `userId` foreign key is `text` referencing `users.id`.
-- `src/middleware.ts` gates protected routes by checking `req.auth` from the NextAuth
-  middleware wrapper.
-- The `(protected)/` route group's `layout.tsx` handles the auth gate client-side
-  via `useSession()` — all child pages can assume the user is authenticated.
-- Required env vars: `DATABASE_URL`, `AUTH_SECRET`, `NEXTAUTH_URL`. That's it —
-  no OAuth client IDs or secrets.
-
----
-
-## Keeping Docs Current
-
-After completing any feature work or making meaningful changes, update `docs/features.md`:
-
-- **Keep current capabilities current**: add or revise user-visible functionality in
-  the appropriate section.
-- **Keep descriptions honest**: write feature notes as user-visible capabilities, not
-  implementation details.
-- **Don't over-document**: trivial bug fixes and refactors don't need feature doc updates.
-  New user-facing features and significant UX changes do.
-
-Also update `docs/build.md` if you change the dev setup, environment variables,
-deployment process, or add new tooling.
-
----
-
-## Do Not
-
-- Add a global state library (Zustand, Redux, Jotai) without discussion.
-- Add a test framework ad-hoc — if tests are needed, plan the framework choice first.
-- Use `console.log` in committed code; use `console.error` only in genuine error paths.
-- Add Prettier or change the ESLint config without updating this file.
+If you add a rule or skill, update `AGENTS.md` (this file) and the relevant
+pointer file so the other tools stay in sync.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": ["AGENTS.md"],
+  "skills": {
+    "paths": [".ai/skills"]
+  }
+}


### PR DESCRIPTION
Closes #52.

## What

Splits the monolithic `AGENTS.md` into a structured `.ai/` directory and rewrites the root file as a thin index.

## Layout

```
.ai/
  rules/       # always-true conventions (13 files)
    stack-and-commands.md
    project-layout.md
    typescript.md
    code-style.md
    backend.md
    error-handling.md
    styling.md
    accessibility.md
    state-management.md
    auth.md
    git-workflow.md          # NEW: draft-PRs-off-main rule
    keeping-docs-current.md
    do-not.md
    iterating-on-ai-docs.md  # NEW: meta-rule for keeping docs current
  skills/       # task-specific end-to-end recipes (4 files)
    adding-backend-endpoint/SKILL.md
    building-client-component/SKILL.md
    schema-migration/SKILL.md
    completing-task/SKILL.md
```

## `AGENTS.md` now a thin index

One-line summaries + links, so the agent loads only the rule or skill relevant to the current task instead of holding everything in context.

## Meta-rule

`.ai/rules/iterating-on-ai-docs.md` directs the agent to keep these docs current whenever it runs into an undocumented convention, a contradiction, or a clarification during work.

## Cross-tool compatibility

`.ai/` is the source of truth; other tools read thin pointers from it:

| Tool | Pointer file |
| ---- | ------------ |
| opencode | `opencode.json` registers `.ai/skills/` as a skills path + `instructions: ["AGENTS.md"]` |
| Claude Code | `CLAUDE.md` `@`-imports `AGENTS.md` |
| GitHub Copilot | `.github/copilot-instructions.md` points to `AGENTS.md` + `.ai/` |

## Verification

- `npm run lint` — clean
- `npm run typecheck` — clean

No app code changed.