### PR TITLE
Card browser with search (issue #16)

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -7,6 +7,11 @@ User-facing capabilities.
 - Create, edit, and remove decks and cards.
 - View card counts, due counts, and last-studied order on decks.
 - Render card content as Markdown (paragraphs, emphasis, lists, inline code).
+- In-deck card browser with text search (front/back), memory-stage filter
+  (New / Learning / Reviewing / Mastered), due-status filter (Overdue / Due
+  today / Upcoming), and sort (oldest / newest / due first / stage). Filtering
+  is client-side against the loaded deck; the card viewer modal walks the
+  filtered set when filters are active.
 
 ## Study workflow
 

--- a/docs/plans/issue-16-card-browser-with-search.md
+++ b/docs/plans/issue-16-card-browser-with-search.md
@@ -1,0 +1,275 @@
+# Issue #16 Plan: Card Browser with Search
+
+Issue: https://github.com/aberiggs/flashcards/issues/16
+
+## Goal
+
+Make it fast to find and open a specific card within a deck. Today the deck
+detail page renders every card as a `CardPreview` tile and forces the user to
+scroll, open, then edit one at a time. Add a searchable, filterable card list
+to the existing `/decks/[id]` page that reuses the current view/edit modal flow.
+
+## Scope (confirmed with user)
+
+- **Surface:** Enhance the existing deck detail page at
+  `src/app/(protected)/decks/[id]/page.tsx`. No new `/cards` route.
+- **Filters:** Text search (front/back), memory stage (New / Learning /
+  Reviewing / Mastered), and due status (Overdue / Due today / Upcoming). No
+  tag filter — tags are deferred to a separate issue (no `tags` column exists
+  yet; a schema migration is out of scope here).
+- **Edit UX:** Reuse the existing `CardViewerModal` + `CardEditForm` for
+  view/edit. Do not build new inline or side-panel editors in this PR.
+- **Responsive:** Works on mobile (filter row collapses to a compact
+  control; list is a single column; tiles stay tappable).
+
+## Non-goals
+
+- Cross-deck browsing (no `/cards` page).
+- Tag filter / tag schema (separate issue).
+- Bulk multi-select / bulk delete / bulk tag (issue mentions as future
+  extension).
+- Replacing the existing card grid for users with no filter applied — the
+  grid remains the default view; the browser is additive.
+
+## Design
+
+Replace the current static "Cards" section (the tile grid at
+`src/app/(protected)/decks/[id]/page.tsx:349-391`) with a richer section that
+has three pieces stacked vertically:
+
+1. **Filter bar** — a single row of compact controls:
+   - Text search input (debounced, reuses the same ILIKE semantics as the
+     global `search` query but applied client-side to the deck's already-
+     loaded cards — no new endpoint needed for the in-deck text filter).
+   - Memory stage dropdown (All / New / Learning / Reviewing / Mastered).
+   - Due status dropdown (All / Overdue / Due today / Upcoming).
+   - Clear-filters button (visible only when any filter is active).
+2. **Result count + sort** — a one-line summary ("12 of 45 cards") with a
+   sort dropdown (Newest first / Oldest first / Due first / Stage asc). Keep
+   the existing "Add Card" button on the right.
+3. **Card list** — the existing `CardPreview` tile grid, now rendering only
+   the filtered subset. Clicking a tile opens `CardViewerModal` exactly as
+   it does today; the modal receives the **filtered** card list so
+   left/right arrow navigation walks the filtered set, not the full deck.
+
+Filtering and sorting happen client-side against the cards already loaded
+by `useDeck(deckId)`. No new backend endpoint, no new hook, no schema change.
+Memory stage is derived from `repetitions` via the existing
+`getMemoryStage` helper in `src/lib/memoryStage.ts`. Due status is derived
+from `nextReview` vs `now()` (and the start-of-today boundary for "Due
+today" vs "Overdue").
+
+## Implementation Plan
+
+### 1. Add a `useFilteredDeckCards` memo in the deck detail page
+
+Pure client-side derivation, no separate file. Inside
+`src/app/(protected)/decks/[id]/page.tsx`:
+
+- Add state: `query`, `stageFilter` (`MemoryStage | 'all'`),
+  `dueFilter` (`'all' | 'overdue' | 'today' | 'upcoming'`), `sortKey`
+  (`'newest' | 'oldest' | 'due' | 'stage'`).
+- Add a debounced `query` (reuse the `useDebounce` pattern from
+  `SearchBar.tsx:31-38` — extract it to `src/lib/useDebounce.ts` so both
+  files share it, or inline a second copy; prefer extraction since the
+  rule is "don't copy bad patterns").
+- Compute `filteredCards` with `useMemo` from `cards`, the debounced
+  query, `stageFilter`, `dueFilter`, and `sortKey`.
+- Pass `filteredCards` (not the full `cards`) into `CardViewerModal`'s
+  `cards` prop and to the grid's `.map`.
+
+### 2. Build a `CardBrowserFilters` component
+
+New file: `src/components/features/decks/CardBrowserFilters.tsx` (client
+component, following `.ai/skills/building-client-component/SKILL.md`).
+
+Props interface:
+```ts
+interface CardBrowserFiltersProps {
+  query: string;
+  onQueryChange: (v: string) => void;
+  stageFilter: MemoryStage | 'all';
+  onStageFilterChange: (v: MemoryStage | 'all') => void;
+  dueFilter: 'all' | 'overdue' | 'today' | 'upcoming';
+  onDueFilterChange: (v: 'all' | 'overdue' | 'today' | 'upcoming') => void;
+  sortKey: 'newest' | 'oldest' | 'due' | 'stage';
+  onSortKeyChange: (v: 'newest' | 'oldest' | 'due' | 'stage') => void;
+  totalCount: number;
+  filteredCount: number;
+  onClear: () => void;
+}
+```
+
+Renders the filter bar described in the Design section. Uses Tailwind v4
+tokens (`bg-surface-secondary`, `border-border-primary`,
+`text-text-tertiary`, `focus:ring-accent-primary`), Lucide icons with
+`aria-hidden`, and `aria-label`s on icon-only buttons. Each dropdown is a
+native `<select>` styled to match the existing
+`bg-surface-secondary border-border-primary` inputs — no custom listbox
+needed.
+
+### 3. Extract `useDebounce`
+
+Move the `useDebounce` function from
+`src/components/layout/SearchBar.tsx:31-38` into
+`src/lib/useDebounce.ts` (named export). Re-export from SearchBar's old
+location is not needed — update the one import in `SearchBar.tsx` and the
+new import in the deck detail page. Keeps the rule "don't copy bad
+patterns."
+
+### 4. Update the deck detail page
+
+In `src/app/(protected)/decks/[id]/page.tsx`:
+
+- Replace the "Section C: Card Browser" block (lines 349-391) with:
+  - `<CardBrowserFilters ... />` at the top.
+  - The existing `Add Card` button row (moved into the filters' right
+    slot or kept as a sibling — whichever is cleaner).
+  - The `CardPreview` grid, mapped over `filteredCards` instead of `cards`.
+  - An empty state when `filteredCards.length === 0` but
+    `cards.length > 0` (i.e. filters excluded everything): a short "No
+    cards match these filters" message plus a Clear button.
+  - Keep the existing empty state when `cards.length === 0` (no cards in
+    deck yet).
+- Update the `CardViewerModal` `cards` prop to receive `filteredCards` so
+  arrow-key navigation walks the filtered set. Track
+  `viewingCardIndex` against `filteredCards`, not the full list.
+- When filters change while the viewer is open, close the viewer to avoid
+  index drift (an effect that watches `query`/`stageFilter`/`dueFilter`/
+  `sortKey` and calls `setViewingCardIndex(null)`).
+
+### 5. Sorting rules
+
+- **Newest first** (default): `createdAt desc` — matches current order
+  when no sort is applied? Current order is `cards.id asc` (see
+  `getDeckWithCards` in `src/server/queries/decks.ts:73`). Switch the
+  default sort to match the existing order (id asc → effectively "Oldest
+  first") so the PR doesn't reorder the deck for users who never touch the
+  sort dropdown. Default `sortKey = 'oldest'`.
+- **Oldest first**: `id asc` (current behavior).
+- **Newest first**: `id desc`.
+- **Due first**: `nextReview asc` (overdue/due first, then upcoming).
+- **Stage asc**: order by `repetitions asc` (New → Mastered).
+
+### 6. No backend changes
+
+No new Route Handler, no new query function, no hook, no schema
+migration. The deck cards are already loaded by `useDeck(deckId)` and
+include `repetitions`, `nextReview`, `createdAt` — everything the filters
+and sorts need.
+
+## Tests
+
+This PR is mostly client-side filtering logic. Per `.ai/rules/do-not.md`
+the test stack is Vitest; pure-logic tests belong in `tests/unit/`. The
+filter/sort derivation is a pure function — extract it so it's testable.
+
+### 7. Extract `filterDeckCards`
+
+New file: `src/lib/filterDeckCards.ts` exporting:
+
+```ts
+export type StageFilter = MemoryStage | 'all';
+export type DueFilter = 'all' | 'overdue' | 'today' | 'upcoming';
+export type CardSortKey = 'newest' | 'oldest' | 'due' | 'stage';
+
+export function filterDeckCards(cards: DeckCard[], opts: {
+  query: string;
+  stageFilter: StageFilter;
+  dueFilter: DueFilter;
+  sortKey: CardSortKey;
+  now: number;          // pass Date.now() from caller; deterministic in tests
+  startOfTodayMs: number; // computed once per render, passed in for testability
+}): DeckCard[];
+```
+
+`DeckCard` is a minimal local type (the fields the filter needs:
+`id`, `front`, `back`, `repetitions`, `nextReview`, `createdAt`). Don't
+import the `Card` type from `src/lib/hooks.ts` (it's the API response
+shape with string dates) — define a small input type that both the page's
+`Card[]` and the test fixtures can satisfy, or just accept `Card[]` and
+coerce `nextReview`/`createdAt` from string to number inside the
+function. Pick whichever is less awkward; prefer not introducing a
+parallel type.
+
+### 8. Unit tests for `filterDeckCards`
+
+New file: `tests/unit/filterDeckCards.test.ts`. Cover:
+
+- Empty query + `stageFilter='all'` + `dueFilter='all'` returns all cards
+  in id-asc order.
+- Text query matches front (case-insensitive), matches back, matches
+  neither → excluded.
+- `stageFilter='learning'` keeps only cards with `repetitions` 1 or 2.
+- `dueFilter='overdue'` keeps `nextReview < startOfTodayMs`.
+- `dueFilter='today'` keeps `startOfTodayMs <= nextReview < startOfTodayMs
+  + 1day`.
+- `dueFilter='upcoming'` keeps `nextReview >= startOfTodayMs + 1day`.
+- `sortKey='due'` orders by `nextReview asc`.
+- `sortKey='stage'` orders by `repetitions asc`.
+- `sortKey='newest'` orders by `id desc`.
+- Combined: text + stage + due filter narrows correctly.
+
+These are pure-logic tests — no Postgres, no testcontainers, fast.
+
+### 9. No new route-handler or server-query tests
+
+No backend changed.
+
+## Explicit Decisions (for review later)
+
+- **Decision:** Filter and sort client-side against `useDeck`'s already-
+  loaded cards.
+  - **Why:** The deck's cards are already fully loaded; sending a new
+    request per keystroke would be slower and would need a new endpoint.
+    Decks are bounded by `MAX_CARDS_PER_DECK` (see `src/lib/limits.ts`),
+    so the client-side cost is bounded.
+  - **Revisit:** If users routinely hit the per-deck cap and complain
+    about jank, move filtering to the server with pagination.
+
+- **Decision:** Default `sortKey = 'oldest'` to preserve current behavior.
+  - **Why:** The PR should not reorder a user's cards out of the box.
+  - **Revisit:** If a "newest first" default is requested, flip it.
+
+- **Decision:** When filters change while the viewer modal is open,
+  close the modal rather than try to keep the current card in view.
+  - **Why:** Keeping the index in sync across a shrinking/growing list is
+    fiddly and error-prone; closing is predictable.
+  - **Revisit:** If users report this as annoying, track the open card by
+    id instead of by index and re-resolve after filtering.
+
+- **Decision:** Use native `<select>` for the filter dropdowns.
+  - **Why:** The existing `SearchBar` builds a custom listbox only because
+    it needs grouped, navigable results. Filters here are short static
+    lists; a native select is accessible, keyboard-friendly, and far
+    less code.
+  - **Revisit:** If design wants custom styling that `<select>` can't
+    express, revisit with a shared `Select` primitive.
+
+- **Decision:** Tags deferred.
+  - **Why:** No tags schema exists; adding one is a separate,
+  schema-migration-sized piece of work the user explicitly opted out of
+  for this PR.
+  - **Revisit:** Open a follow-up issue for `tags text[]` on `cards` (or a
+  `tags` + `card_tags` join) + a tag filter dropdown.
+
+## Validation Checklist
+
+- [ ] Text search filters cards by front and back content (case-insensitive).
+- [ ] Memory stage dropdown filters to the selected stage.
+- [ ] Due status dropdown filters to overdue / due today / upcoming.
+- [ ] Sort dropdown reorders the grid (oldest / newest / due first / stage asc).
+- [ ] Result count ("X of Y cards") reflects the active filters.
+- [ ] Clear filters button resets all filters to their defaults.
+- [ ] Clicking a filtered tile opens `CardViewerModal` walking the
+      filtered list, not the full deck.
+- [ ] Changing filters while the viewer is open closes the viewer cleanly.
+- [ ] Layout works on mobile (single column, controls stack, no horizontal
+      overflow).
+- [ ] `useDebounce` extracted and shared between `SearchBar` and the new
+      filter input.
+- [ ] `filterDeckCards` unit tests pass.
+- [ ] `npm run lint` passes.
+- [ ] `npm run typecheck` passes.
+- [ ] `npm run test` passes (Docker running for testcontainers).
+- [ ] `docs/features.md` updated to mention the in-deck card browser.

--- a/src/app/(protected)/decks/[id]/page.tsx
+++ b/src/app/(protected)/decks/[id]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useParams, useRouter } from 'next/navigation';
-import { useState, useEffect, useRef, useMemo } from 'react';
+import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { Pencil, Trash2, Plus, Layers } from 'lucide-react';
 import { useDeck, useDeckStats, useDeckIntervalStats, useUpdateDeck, useDeleteDeck, useCreateCard, useUpdateCard, useDeleteCard, type Card } from '@/lib/hooks';
 import { useDebounce } from '@/lib/useDebounce';
@@ -59,9 +59,11 @@ export default function DeckDetailPage() {
     const [cardToDeleteId, setCardToDeleteId] = useState<number | null>(null);
     const [isDeletingCard, setIsDeletingCard] = useState(false);
     const [isDeletingDeck, setIsDeletingDeck] = useState(false);
-    const [viewingCardIndex, setViewingCardIndex] = useState<number | null>(null);
+    // Track the viewed card by id (not index) so sort-only changes keep the
+    // same card in view — its position in viewerCards just updates.
+    const [viewingCardId, setViewingCardId] = useState<number | null>(null);
     const [showingCardInfo, setShowingCardInfo] = useState(false);
-    const [infoCardIndex, setInfoCardIndex] = useState(0);
+    const [infoCardId, setInfoCardId] = useState<number | null>(null);
 
     // ── Card browser filters ────────────────────────────────────────────────
     const [filterQuery, setFilterQuery] = useState('');
@@ -71,10 +73,16 @@ export default function DeckDetailPage() {
     const debouncedQuery = useDebounce(filterQuery, 200);
 
     // Recompute start-of-today once per render. Fine to recompute — it's cheap
-    // and stays consistent across renders within the same calendar day.
+    // and stays consistent across renders within the same calendar day. We
+    // also key the memo on the current calendar date in the user's tz so it
+    // recomputes when `now` crosses into a new day (e.g. the user leaves the
+    // page open past midnight); within the same day the result is identical
+    // so the extra work is a no-op.
+    const now = Date.now();
     const startOfTodayMs = useMemo(
         () => startOfTodayInTimezone(timeZone),
-        [timeZone]
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [timeZone, new Date(now).toLocaleDateString('en-CA', { timeZone })]
     );
 
     const allCards: Card[] = useMemo(
@@ -94,25 +102,57 @@ export default function DeckDetailPage() {
         [allCards, debouncedQuery, stageFilter, dueFilter, sortKey, startOfTodayMs]
     );
 
-    // Cards passed to the viewer modal — the filtered set when filters are
-    // active, otherwise the full deck. The viewer's arrow-key navigation
-    // walks this list. Use a Set for the membership check so a 500-card
-    // deck doesn't degrade to O(n²) on every render.
-    const filteredCardIds = useMemo(
-        () => new Set(filteredCards.map((c) => c.id)),
-        [filteredCards]
+    // Cards passed to the viewer modal — the filtered set (in the same
+    // order the grid displays it) when filters are active, otherwise the
+    // full deck. The viewer's arrow-key navigation walks this list, so it
+    // must match the grid's sort order. Map the filtered DeckCardOutput
+    // back to the original Card objects (which carry Date fields the
+    // viewer modal needs) by id.
+    const cardsById = useMemo(
+        () => new Map(allCards.map((c) => [c.id, c])),
+        [allCards]
     );
-    const viewerCards: Card[] = filteredCards.length < allCards.length
-        ? allCards.filter((c) => filteredCardIds.has(c.id))
-        : allCards;
+    const viewerCards: Card[] = useMemo(
+        () => filteredCards.length < allCards.length
+            ? filteredCards.map((c) => cardsById.get(c.id)).filter((c): c is Card => c !== undefined)
+            : allCards,
+        [filteredCards, allCards, cardsById]
+    );
 
-    // Close the viewer if filters change while it's open. Tracking by id
-    // would be cleaner, but the existing modal uses indices and rewiring
-    // that is out of scope for this PR.
+    // Close the viewer if filters change the membership of the visible
+    // set. Sort-only changes don't alter which cards are visible, so we
+    // intentionally exclude `sortKey` — the viewer stays on the same
+    // card (tracked by id) and walks viewerCards in the new sorted order.
     useEffect(() => {
-        setViewingCardIndex(null);
+        setViewingCardId(null);
         setShowingCardInfo(false);
-    }, [debouncedQuery, stageFilter, dueFilter, sortKey]);
+    }, [debouncedQuery, stageFilter, dueFilter]);
+
+    // Resolve the viewed card's id to an index into viewerCards. Recompute
+    // whenever the set or order changes — e.g. a sort change moves the
+    // viewed card to a different index, and we want the viewer to follow it.
+    const viewingCardIndex = useMemo(() => {
+        if (viewingCardId === null) return null;
+        const idx = viewerCards.findIndex((c) => c.id === viewingCardId);
+        return idx === -1 ? null : idx;
+    }, [viewingCardId, viewerCards]);
+
+    const infoCardIndex = useMemo(() => {
+        if (infoCardId === null || viewerCards.length === 0) return 0;
+        const idx = viewerCards.findIndex((c) => c.id === infoCardId);
+        return idx === -1 ? 0 : idx;
+    }, [infoCardId, viewerCards]);
+
+    // Track the currently-viewed card by id as the user navigates inside the
+    // viewer. Stabilized with useCallback so CardViewerModal's navigation
+    // effect doesn't re-fire on every parent render.
+    const handleViewerNavigate = useCallback(
+        (index: number) => {
+            const card = viewerCards[index];
+            if (card) setViewingCardId(card.id);
+        },
+        [viewerCards]
+    );
 
     const handleClearFilters = () => {
         setFilterQuery('');
@@ -174,7 +214,6 @@ export default function DeckDetailPage() {
     }
 
     const cards: Card[] = deckWithCards.cards;
-    const now = Date.now();
     const dueCount = cards.filter((c) => new Date(c.nextReview).getTime() <= now).length;
     const hasDue = dueCount > 0;
 
@@ -468,15 +507,14 @@ export default function DeckDetailPage() {
                                     </div>
                                 ) : (
                                     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-                                        {filteredCards.map((card) => {
-                                            const originalIndex = cards.findIndex((c) => c.id === card.id);
+                                        {filteredCards.map((card, gridIndex) => {
                                             return (
                                                 <CardPreview
                                                     key={card.id}
                                                     front={card.front}
-                                                    index={originalIndex}
+                                                    index={gridIndex}
                                                     onClick={() => {
-                                                        setViewingCardIndex(viewerCards.findIndex((c) => c.id === card.id));
+                                                        setViewingCardId(card.id);
                                                         setShowingCardInfo(false);
                                                     }}
                                                 />
@@ -496,12 +534,12 @@ export default function DeckDetailPage() {
                 initialIndex={viewingCardIndex ?? 0}
                 isOpen={viewingCardIndex !== null}
                 onClose={() => {
-                    setViewingCardIndex(null);
+                    setViewingCardId(null);
                     setShowingCardInfo(false);
                 }}
                 onEdit={handleEditCard}
                 onDelete={(cardId) => {
-                    setViewingCardIndex(null);
+                    setViewingCardId(null);
                     openDeleteCardModal(cardId);
                 }}
                 infoContent={
@@ -531,9 +569,11 @@ export default function DeckDetailPage() {
                 }
                 onCancelInfo={() => setShowingCardInfo(false)}
                 onShowInfo={(index) => {
-                    setInfoCardIndex(index);
+                    const card = viewerCards[index];
+                    if (card) setInfoCardId(card.id);
                     setShowingCardInfo(true);
                 }}
+                onNavigate={handleViewerNavigate}
             />
 
             {/* Add Card Modal */}

--- a/src/app/(protected)/decks/[id]/page.tsx
+++ b/src/app/(protected)/decks/[id]/page.tsx
@@ -1,9 +1,12 @@
 'use client';
 
 import { useParams, useRouter } from 'next/navigation';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import { Pencil, Trash2, Plus, Layers } from 'lucide-react';
 import { useDeck, useDeckStats, useDeckIntervalStats, useUpdateDeck, useDeleteDeck, useCreateCard, useUpdateCard, useDeleteCard, type Card } from '@/lib/hooks';
+import { useDebounce } from '@/lib/useDebounce';
+import { filterDeckCards, type CardSortKey, type DueFilter, type StageFilter } from '@/lib/filterDeckCards';
+import { startOfTodayInTimezone } from '@/lib/startOfToday';
 import { Modal } from '@/components/ui/Modal';
 import { useToast } from '@/components/ui/Toast';
 import { getMemoryStage } from '@/lib/memoryStage';
@@ -15,6 +18,7 @@ import { IntervalStatsWidget } from '@/components/features/dashboard/IntervalSta
 import { CardPreview } from '@/components/features/decks/CardPreview';
 import { CardViewerModal } from '@/components/features/decks/CardViewerModal';
 import { CardEditForm } from '@/components/features/decks/CardEditForm';
+import { CardBrowserFilters } from '@/components/features/decks/CardBrowserFilters';
 import { ExportDeckButton } from '@/components/features/decks/ExportDeckButton';
 import Link from 'next/link';
 
@@ -58,6 +62,59 @@ export default function DeckDetailPage() {
     const [viewingCardIndex, setViewingCardIndex] = useState<number | null>(null);
     const [showingCardInfo, setShowingCardInfo] = useState(false);
     const [infoCardIndex, setInfoCardIndex] = useState(0);
+
+    // ── Card browser filters ────────────────────────────────────────────────
+    const [filterQuery, setFilterQuery] = useState('');
+    const [stageFilter, setStageFilter] = useState<StageFilter>('all');
+    const [dueFilter, setDueFilter] = useState<DueFilter>('all');
+    const [sortKey, setSortKey] = useState<CardSortKey>('oldest');
+    const debouncedQuery = useDebounce(filterQuery, 200);
+
+    // Recompute start-of-today once per render. Fine to recompute — it's cheap
+    // and stays consistent across renders within the same calendar day.
+    const startOfTodayMs = useMemo(
+        () => startOfTodayInTimezone(timeZone),
+        [timeZone]
+    );
+
+    const allCards: Card[] = useMemo(
+        () => deckWithCards?.cards ?? [],
+        [deckWithCards]
+    );
+
+    const filteredCards = useMemo(
+        () => filterDeckCards(allCards, {
+            query: debouncedQuery,
+            stageFilter,
+            dueFilter,
+            sortKey,
+            now: Date.now(),
+            startOfTodayMs,
+        }),
+        [allCards, debouncedQuery, stageFilter, dueFilter, sortKey, startOfTodayMs]
+    );
+
+    // Cards passed to the viewer modal — the filtered set when filters are
+    // active, otherwise the full deck. The viewer's arrow-key navigation
+    // walks this list.
+    const viewerCards: Card[] = filteredCards.length < allCards.length
+        ? allCards.filter((c) => filteredCards.some((f) => f.id === c.id))
+        : allCards;
+
+    // Close the viewer if filters change while it's open. Tracking by id
+    // would be cleaner, but the existing modal uses indices and rewiring
+    // that is out of scope for this PR.
+    useEffect(() => {
+        setViewingCardIndex(null);
+        setShowingCardInfo(false);
+    }, [debouncedQuery, stageFilter, dueFilter, sortKey]);
+
+    const handleClearFilters = () => {
+        setFilterQuery('');
+        setStageFilter('all');
+        setDueFilter('all');
+        setSortKey('oldest');
+    };
 
     const nameInputRef = useRef<HTMLInputElement>(null);
     const descInputRef = useRef<HTMLTextAreaElement>(null);
@@ -374,26 +431,63 @@ export default function DeckDetailPage() {
                             </button>
                         </div>
                     ) : (
-                        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-                            {cards.map((card, index) => (
-                                <CardPreview
-                                    key={card.id}
-                                    front={card.front}
-                                    index={index}
-                                    onClick={() => {
-                                    setViewingCardIndex(index);
-                                    setShowingCardInfo(false);
-                                }}
-                                />
-                            ))}
-                        </div>
+                        <>
+                            <CardBrowserFilters
+                                query={filterQuery}
+                                onQueryChange={setFilterQuery}
+                                stageFilter={stageFilter}
+                                onStageFilterChange={setStageFilter}
+                                dueFilter={dueFilter}
+                                onDueFilterChange={setDueFilter}
+                                sortKey={sortKey}
+                                onSortKeyChange={setSortKey}
+                                totalCount={cards.length}
+                                filteredCount={filteredCards.length}
+                                onClear={handleClearFilters}
+                            />
+
+                            <div className="mt-4">
+                                {filteredCards.length === 0 ? (
+                                    <div className="rounded-xl border border-border-primary bg-surface-primary p-12 text-center">
+                                        <p className="text-text-secondary mb-4">No cards match these filters.</p>
+                                        <button
+                                            type="button"
+                                            onClick={handleClearFilters}
+                                            className="inline-flex items-center gap-1.5 px-4 py-2.5 rounded-lg text-sm font-medium
+                                                       border border-border-primary text-text-primary bg-surface-secondary
+                                                       hover:bg-surface-tertiary transition-colors cursor-pointer
+                                                       focus:outline-none focus:ring-2 focus:ring-accent-primary"
+                                        >
+                                            Clear filters
+                                        </button>
+                                    </div>
+                                ) : (
+                                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                                        {filteredCards.map((card) => {
+                                            const originalIndex = cards.findIndex((c) => c.id === card.id);
+                                            return (
+                                                <CardPreview
+                                                    key={card.id}
+                                                    front={card.front}
+                                                    index={originalIndex}
+                                                    onClick={() => {
+                                                        setViewingCardIndex(viewerCards.findIndex((c) => c.id === card.id));
+                                                        setShowingCardInfo(false);
+                                                    }}
+                                                />
+                                            );
+                                        })}
+                                    </div>
+                                )}
+                            </div>
+                        </>
                     )}
                 </section>
             </main>
 
-            {/* Card Viewer Modal */}
+            {/* Card Viewer Modal — walks the filtered list when filters active */}
             <CardViewerModal
-                cards={cards}
+                cards={viewerCards}
                 initialIndex={viewingCardIndex ?? 0}
                 isOpen={viewingCardIndex !== null}
                 onClose={() => {
@@ -406,9 +500,9 @@ export default function DeckDetailPage() {
                     openDeleteCardModal(cardId);
                 }}
                 infoContent={
-                    viewingCardIndex !== null && showingCardInfo && cards.length > 0 ? (() => {
-                        const safeInfoIndex = Math.min(infoCardIndex, cards.length - 1);
-                        const infoCard = cards[safeInfoIndex];
+                    viewingCardIndex !== null && showingCardInfo && viewerCards.length > 0 ? (() => {
+                        const safeInfoIndex = Math.min(infoCardIndex, viewerCards.length - 1);
+                        const infoCard = viewerCards[safeInfoIndex];
                         const reps = infoCard.repetitions;
                         const stage = getMemoryStage(reps);
                         const nextReviewMs = new Date(infoCard.nextReview).getTime();

--- a/src/app/(protected)/decks/[id]/page.tsx
+++ b/src/app/(protected)/decks/[id]/page.tsx
@@ -96,9 +96,14 @@ export default function DeckDetailPage() {
 
     // Cards passed to the viewer modal — the filtered set when filters are
     // active, otherwise the full deck. The viewer's arrow-key navigation
-    // walks this list.
+    // walks this list. Use a Set for the membership check so a 500-card
+    // deck doesn't degrade to O(n²) on every render.
+    const filteredCardIds = useMemo(
+        () => new Set(filteredCards.map((c) => c.id)),
+        [filteredCards]
+    );
     const viewerCards: Card[] = filteredCards.length < allCards.length
-        ? allCards.filter((c) => filteredCards.some((f) => f.id === c.id))
+        ? allCards.filter((c) => filteredCardIds.has(c.id))
         : allCards;
 
     // Close the viewer if filters change while it's open. Tracking by id

--- a/src/components/features/decks/CardBrowserFilters.tsx
+++ b/src/components/features/decks/CardBrowserFilters.tsx
@@ -165,8 +165,6 @@ export function CardBrowserFilters({
           className="min-w-[150px] flex-1 sm:flex-none sm:w-auto"
         />
 
-        <div className="hidden sm:block w-px h-7 bg-border-primary mx-1" aria-hidden />
-
         <Dropdown
           options={SORT_OPTIONS}
           value={sortKey}

--- a/src/components/features/decks/CardBrowserFilters.tsx
+++ b/src/components/features/decks/CardBrowserFilters.tsx
@@ -68,7 +68,7 @@ export function CardBrowserFilters({
   const filtered = filteredCount < totalCount;
 
   return (
-    <div className="rounded-xl border border-border-primary bg-surface-primary shadow-sm overflow-hidden">
+    <div className="rounded-xl border border-border-primary bg-surface-primary shadow-sm">
       {/* ── Row 1: search + count ─────────────────────────────────────────── */}
       <div className="flex flex-col sm:flex-row sm:items-center gap-3 p-4 sm:px-5 sm:py-4 border-b border-border-primary">
         <div className="relative flex-1 min-w-0">

--- a/src/components/features/decks/CardBrowserFilters.tsx
+++ b/src/components/features/decks/CardBrowserFilters.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import { Search, X, Filter, CalendarClock, GraduationCap, ArrowDownUp } from 'lucide-react';
+import { Dropdown, type DropdownOption } from '@/components/ui/Dropdown';
+import {
+  type CardSortKey,
+  type DueFilter,
+  type StageFilter,
+  isFilterActive,
+} from '@/lib/filterDeckCards';
+
+// ── Props ────────────────────────────────────────────────────────────────────
+
+export interface CardBrowserFiltersProps {
+  query: string;
+  onQueryChange: (v: string) => void;
+  stageFilter: StageFilter;
+  onStageFilterChange: (v: StageFilter) => void;
+  dueFilter: DueFilter;
+  onDueFilterChange: (v: DueFilter) => void;
+  sortKey: CardSortKey;
+  onSortKeyChange: (v: CardSortKey) => void;
+  totalCount: number;
+  filteredCount: number;
+  onClear: () => void;
+}
+
+// ── Option tables ───────────────────────────────────────────────────────────
+
+const STAGE_OPTIONS: DropdownOption[] = [
+  { value: 'all', label: 'All stages' },
+  { value: 'New', label: 'New' },
+  { value: 'Learning', label: 'Learning' },
+  { value: 'Reviewing', label: 'Reviewing' },
+  { value: 'Mastered', label: 'Mastered' },
+];
+
+const DUE_OPTIONS: DropdownOption[] = [
+  { value: 'all', label: 'Any due status' },
+  { value: 'overdue', label: 'Overdue' },
+  { value: 'today', label: 'Due today' },
+  { value: 'upcoming', label: 'Upcoming' },
+];
+
+const SORT_OPTIONS: DropdownOption[] = [
+  { value: 'oldest', label: 'Oldest first' },
+  { value: 'newest', label: 'Newest first' },
+  { value: 'due', label: 'Due first' },
+  { value: 'stage', label: 'Stage (low → high)' },
+];
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+export function CardBrowserFilters({
+  query,
+  onQueryChange,
+  stageFilter,
+  onStageFilterChange,
+  dueFilter,
+  onDueFilterChange,
+  sortKey,
+  onSortKeyChange,
+  totalCount,
+  filteredCount,
+  onClear,
+}: CardBrowserFiltersProps) {
+  const active = isFilterActive({ query, stageFilter, dueFilter, sortKey });
+  const filtered = filteredCount < totalCount;
+
+  return (
+    <div className="rounded-xl border border-border-primary bg-surface-primary shadow-sm overflow-hidden">
+      {/* ── Row 1: search + count ─────────────────────────────────────────── */}
+      <div className="flex flex-col sm:flex-row sm:items-center gap-3 p-4 sm:px-5 sm:py-4 border-b border-border-primary">
+        <div className="relative flex-1 min-w-0">
+          <Search
+            className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-text-tertiary pointer-events-none"
+            aria-hidden
+          />
+          <input
+            type="search"
+            value={query}
+            onChange={(e) => onQueryChange(e.target.value)}
+            placeholder="Search cards in this deck…"
+            aria-label="Search cards in this deck"
+            className="w-full min-h-[40px] pl-9 pr-9 rounded-lg border border-border-primary bg-surface-secondary text-sm text-text-primary
+                       placeholder:text-text-tertiary transition-colors
+                       hover:border-border-secondary
+                       focus:outline-none focus:ring-2 focus:ring-accent-primary focus:border-transparent"
+          />
+          {query && (
+            <button
+              type="button"
+              onClick={() => onQueryChange('')}
+              aria-label="Clear search"
+              className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center justify-center size-7
+                         rounded-md text-text-tertiary hover:text-text-primary hover:bg-surface-tertiary transition-colors cursor-pointer
+                         focus:outline-none focus:ring-2 focus:ring-accent-primary"
+            >
+              <X className="size-3.5" aria-hidden />
+            </button>
+          )}
+        </div>
+
+        <div className="flex items-center justify-between sm:justify-end gap-3 shrink-0">
+          <span
+            className="text-xs tabular-nums text-text-tertiary"
+            aria-live="polite"
+          >
+            {filtered ? (
+              <>
+                <span className="font-medium text-text-secondary">{filteredCount}</span>
+                <span className="text-text-tertiary"> of {totalCount}</span>
+              </>
+            ) : (
+              <>
+                <span className="font-medium text-text-secondary">{totalCount}</span>{' '}
+                {totalCount === 1 ? 'card' : 'cards'}
+              </>
+            )}
+          </span>
+
+          {active && (
+            <button
+              type="button"
+              onClick={onClear}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium
+                         text-text-secondary border border-border-primary bg-surface-secondary
+                         hover:bg-surface-tertiary hover:text-text-primary transition-colors cursor-pointer
+                         focus:outline-none focus:ring-2 focus:ring-accent-primary"
+            >
+              <X className="size-3.5" aria-hidden />
+              Clear filters
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* ── Row 2: filter chips ───────────────────────────────────────────── */}
+      <div className="flex flex-wrap items-center gap-2 p-3 sm:px-5 sm:py-3 bg-surface-secondary/50">
+        <span
+          className="hidden sm:inline-flex items-center gap-1.5 text-xs font-medium uppercase tracking-wider text-text-tertiary shrink-0 pr-1"
+          aria-hidden
+        >
+          <Filter className="size-3.5" />
+          Filter
+        </span>
+
+        <Dropdown
+          options={STAGE_OPTIONS}
+          value={stageFilter}
+          onValueChange={(v) => onStageFilterChange(v as StageFilter)}
+          ariaLabel="Filter by memory stage"
+          leadingIcon={<GraduationCap className="size-4" />}
+          variant="compact"
+          className="min-w-[150px] flex-1 sm:flex-none sm:w-auto"
+        />
+
+        <Dropdown
+          options={DUE_OPTIONS}
+          value={dueFilter}
+          onValueChange={(v) => onDueFilterChange(v as DueFilter)}
+          ariaLabel="Filter by due status"
+          leadingIcon={<CalendarClock className="size-4" />}
+          variant="compact"
+          className="min-w-[150px] flex-1 sm:flex-none sm:w-auto"
+        />
+
+        <div className="hidden sm:block w-px h-7 bg-border-primary mx-1" aria-hidden />
+
+        <Dropdown
+          options={SORT_OPTIONS}
+          value={sortKey}
+          onValueChange={(v) => onSortKeyChange(v as CardSortKey)}
+          ariaLabel="Sort cards"
+          leadingIcon={<ArrowDownUp className="size-4" />}
+          variant="compact"
+          className="min-w-[150px] flex-1 sm:flex-none sm:w-auto sm:ml-auto"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/decks/CardViewerModal.tsx
+++ b/src/components/features/decks/CardViewerModal.tsx
@@ -19,6 +19,9 @@ interface CardViewerModalProps {
     onCancelInfo?: () => void;
     /** Called when user clicks the info button; receives the current card index so the parent can show that card's info. */
     onShowInfo?: (cardIndex: number) => void;
+    /** Called when the user navigates within the viewer (arrows / type-ahead),
+     *  so the parent can track the currently-viewed card by id. */
+    onNavigate?: (cardIndex: number) => void;
 }
 
 export function CardViewerModal({
@@ -31,6 +34,7 @@ export function CardViewerModal({
     infoContent = null,
     onCancelInfo,
     onShowInfo,
+    onNavigate,
 }: CardViewerModalProps) {
     const [currentIndex, setCurrentIndex] = useState(initialIndex);
     const [isFlipped, setIsFlipped] = useState(false);
@@ -44,6 +48,11 @@ export function CardViewerModal({
         setIsFlipped(false);
         setIsEditing(false);
     }, [initialIndex]);
+
+    // Notify parent of navigation so it can track the viewed card by id.
+    useEffect(() => {
+        if (isOpen) onNavigate?.(currentIndex);
+    }, [currentIndex, isOpen, onNavigate]);
 
     const safeIndex = Math.min(currentIndex, cards.length - 1);
     const card = cards[safeIndex];

--- a/src/components/layout/SearchBar.tsx
+++ b/src/components/layout/SearchBar.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react';
 import { useRouter } from 'next/navigation';
 import { useSearch } from '@/lib/hooks';
+import { useDebounce } from '@/lib/useDebounce';
 import { Search, Layers, CreditCard, X } from 'lucide-react';
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -27,15 +28,6 @@ interface CardResult {
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
-
-function useDebounce<T>(value: T, delayMs: number): T {
-  const [debounced, setDebounced] = useState(value);
-  useEffect(() => {
-    const id = setTimeout(() => setDebounced(value), delayMs);
-    return () => clearTimeout(id);
-  }, [value, delayMs]);
-  return debounced;
-}
 
 function truncate(text: string, max: number): string {
   return text.length <= max ? text : text.slice(0, max) + '…';

--- a/src/components/ui/Dropdown.tsx
+++ b/src/components/ui/Dropdown.tsx
@@ -1,0 +1,272 @@
+'use client';
+
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { Check, ChevronDown } from 'lucide-react';
+
+/**
+ * Accessible listbox-style dropdown. Implements the WAI-ARIA combobox /
+ * listbox pattern (https://www.w3.org/WAI/ARIA/apg/patterns/listbox/):
+ *
+ *   - Trigger: <button> with `aria-haspopup="listbox"` and `aria-expanded`.
+ *   - Popup:   <ul role="listbox"> with <li role="option"> children.
+ *   - Keyboard: Enter / Space to open, Arrow keys to move, Enter / Space to
+ *     select, Escape to close, Home / End to jump, type-ahead to find.
+ *   - Focus: trigger keeps DOM focus; the active option is tracked via
+ *     `aria-activedescendant` so screen readers announce it.
+ *   - Click outside or Escape closes and returns focus to the trigger.
+ *
+ * No native <select> — fully custom for sleek styling while staying
+ * keyboard- and screen-reader-friendly.
+ *
+ * Variants:
+ *   - `default`: full-width trigger with a left-aligned label.
+ *   - `compact`:  the trigger shows only an icon + current value, sized for
+ *     dense filter bars (see CardBrowserFilters).
+ */
+
+export interface DropdownOption {
+  value: string;
+  label: string;
+  /** Optional short label shown in the trigger when this option is selected. */
+  triggerLabel?: string;
+}
+
+export interface DropdownProps {
+  options: DropdownOption[];
+  value: string;
+  onValueChange: (value: string) => void;
+  /** Visible label above the trigger (desktop form-style). Optional. */
+  label?: string;
+  /** Accessible name when no visible label is shown. Required. */
+  ariaLabel: string;
+  /** Icon rendered inside the trigger, left of the value. Optional. */
+  leadingIcon?: React.ReactNode;
+  variant?: 'default' | 'compact';
+  disabled?: boolean;
+  /** Optional className applied to the trigger wrapper. */
+  className?: string;
+}
+
+export function Dropdown({
+  options,
+  value,
+  onValueChange,
+  label,
+  ariaLabel,
+  leadingIcon,
+  variant = 'default',
+  disabled = false,
+  className = '',
+}: DropdownProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+  const listboxId = useId();
+
+  const selectedIndex = useMemo(
+    () => Math.max(
+      0,
+      options.findIndex((o) => o.value === value)
+    ),
+    [options, value]
+  );
+
+  // Open with the currently-selected option focused so the keyboard user
+  // can immediately adjust from their current choice.
+  useEffect(() => {
+    if (isOpen) setActiveIndex(selectedIndex);
+  }, [isOpen, selectedIndex]);
+
+  // Click outside → close
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleClick = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (
+        triggerRef.current?.contains(target) ||
+        listRef.current?.contains(target)
+      ) {
+        return;
+      }
+      setIsOpen(false);
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [isOpen]);
+
+  // Scroll active option into view
+  useEffect(() => {
+    if (!isOpen || activeIndex < 0 || !listRef.current) return;
+    const items = listRef.current.querySelectorAll('[role="option"]');
+    const el = items[activeIndex] as HTMLElement | undefined;
+    el?.scrollIntoView({ block: 'nearest' });
+  }, [activeIndex, isOpen]);
+
+  const closeAndFocusTrigger = useCallback(() => {
+    setIsOpen(false);
+    requestAnimationFrame(() => triggerRef.current?.focus());
+  }, []);
+
+  const selectIndex = useCallback(
+    (index: number) => {
+      const option = options[index];
+      if (!option) return;
+      onValueChange(option.value);
+      closeAndFocusTrigger();
+    },
+    [options, onValueChange, closeAndFocusTrigger]
+  );
+
+  const handleTriggerKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    // When open, the trigger owns all keyboard interaction (combobox pattern:
+    // focus stays on the trigger, aria-activedescendant on the listbox points
+    // at the active option). When closed, Arrow/Enter/Space open the list.
+    if (!isOpen) {
+      switch (e.key) {
+        case 'ArrowDown':
+        case 'ArrowUp':
+        case 'Enter':
+        case ' ':
+        case 'Spacebar':
+          e.preventDefault();
+          setIsOpen(true);
+          break;
+      }
+      return;
+    }
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        setActiveIndex((i) => Math.min((i < 0 ? 0 : i + 1), options.length - 1));
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        setActiveIndex((i) => Math.max(i - 1, 0));
+        break;
+      case 'Home':
+        e.preventDefault();
+        setActiveIndex(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        setActiveIndex(options.length - 1);
+        break;
+      case 'Enter':
+      case ' ':
+      case 'Spacebar':
+        e.preventDefault();
+        if (activeIndex >= 0) selectIndex(activeIndex);
+        break;
+      case 'Escape':
+        e.preventDefault();
+        closeAndFocusTrigger();
+        break;
+      case 'Tab':
+        setIsOpen(false);
+        break;
+    }
+  };
+
+  const selectedOption = options[selectedIndex];
+  const triggerDisplay = selectedOption?.triggerLabel ?? selectedOption?.label ?? '';
+
+  const isCompact = variant === 'compact';
+
+  return (
+    <div className={`relative ${className}`}>
+      {label && (
+        <label
+          id={`${listboxId}-label`}
+          className="block text-xs font-medium text-text-tertiary uppercase tracking-wider mb-1.5"
+        >
+          {label}
+        </label>
+      )}
+
+      <button
+        ref={triggerRef}
+        type="button"
+        disabled={disabled}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        aria-controls={isOpen ? listboxId : undefined}
+        aria-label={ariaLabel}
+        onClick={() => !disabled && setIsOpen((o) => !o)}
+        onKeyDown={handleTriggerKeyDown}
+        className={`group flex w-full items-center gap-2 rounded-lg border border-border-primary bg-surface-secondary text-text-primary
+          transition-colors
+          hover:bg-surface-tertiary hover:border-border-secondary
+          focus:outline-none focus:ring-2 focus:ring-accent-primary focus:border-transparent
+          disabled:opacity-50 disabled:cursor-not-allowed
+          ${isCompact ? 'min-h-[40px] px-3 text-sm' : 'min-h-[44px] px-3.5 text-sm'}
+          cursor-pointer`}
+      >
+        {leadingIcon && (
+          <span className="shrink-0 text-text-tertiary group-hover:text-text-secondary transition-colors">
+            {leadingIcon}
+          </span>
+        )}
+        <span className="flex-1 truncate text-left">{triggerDisplay}</span>
+        <ChevronDown
+          className={`shrink-0 text-text-tertiary transition-transform duration-200 ${
+            isOpen ? 'rotate-180' : ''
+          }`}
+          aria-hidden
+        />
+      </button>
+
+      {isOpen && (
+        <ul
+          ref={listRef}
+          id={listboxId}
+          role="listbox"
+          tabIndex={-1}
+          aria-activedescendant={
+            activeIndex >= 0 ? `${listboxId}-opt-${activeIndex}` : undefined
+          }
+          aria-label={ariaLabel}
+          className="absolute z-50 mt-1.5 w-full overflow-auto rounded-lg border border-border-primary bg-surface-primary shadow-lg
+                     max-h-60 py-1 animate-fade-in-up outline-none"
+        >
+          {options.map((option, index) => {
+            const isActive = index === activeIndex;
+            const isSelected = option.value === value;
+            return (
+              <li
+                key={option.value}
+                id={`${listboxId}-opt-${index}`}
+                role="option"
+                aria-selected={isSelected}
+                onMouseDown={(e) => {
+                  // Prevent the trigger's blur from firing before click lands.
+                  e.preventDefault();
+                }}
+                onMouseEnter={() => setActiveIndex(index)}
+                onClick={() => selectIndex(index)}
+                className={`flex items-center gap-2 px-3 py-2 text-sm cursor-pointer select-none transition-colors
+                  ${isActive ? 'bg-accent-primary/10 text-text-primary' : 'text-text-secondary hover:bg-surface-secondary hover:text-text-primary'}`}
+              >
+                <span className="flex-1 truncate">{option.label}</span>
+                {isSelected && (
+                  <Check
+                    className="shrink-0 size-4 text-accent-primary"
+                    aria-hidden
+                  />
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/Dropdown.tsx
+++ b/src/components/ui/Dropdown.tsx
@@ -71,6 +71,13 @@ export function Dropdown({
   const listRef = useRef<HTMLUListElement>(null);
   const listboxId = useId();
 
+  // Anchoring for the listbox. The listbox sizes to its content (w-max) and
+  // attaches to the left or right edge of the trigger depending on which side
+  // has more room. Re-measured on every open so it survives resize/scroll.
+  const [listboxStyle, setListboxStyle] = useState<React.CSSProperties>({
+    minWidth: 'max-content',
+  });
+
   const selectedIndex = useMemo(
     () => Math.max(
       0,
@@ -79,13 +86,59 @@ export function Dropdown({
     [options, value]
   );
 
+  // Position the listbox relative to the trigger. Called on open and on
+  // viewport changes while open. The listbox is sized to fit its longest
+  // option (measured off-screen) and anchored to the left or right edge of
+  // the trigger depending on which side has more room.
+  const measureAndPosition = useCallback(() => {
+    const trigger = triggerRef.current;
+    const list = listRef.current;
+    if (!trigger || !list) return;
+    const tRect = trigger.getBoundingClientRect();
+    const vw = window.innerWidth;
+    const margin = 8; // px of breathing room from the viewport edge
+
+    // Measure the natural (untruncated) width of the widest option. We use
+    // scrollWidth because it reports the content's natural width even when
+    // the span is currently being clipped by the listbox's initial width.
+    const optionSpans = Array.from(list.querySelectorAll('[data-option-text]'));
+    let contentWidth = 0;
+    for (const span of optionSpans) {
+      const spanEl = span as HTMLElement;
+      contentWidth = Math.max(contentWidth, spanEl.scrollWidth);
+    }
+    // Add horizontal padding (px-3 = 12px each side = 24px), the check icon
+    // column (size-4 + gap-2 = 16+8 = 24px), and a small buffer.
+    const naturalListWidth = Math.ceil(contentWidth) + 24 + 24 + 4;
+
+    const spaceRight = vw - tRect.left - margin;
+    const spaceLeft = tRect.right - margin;
+    const fitsOnRight = naturalListWidth <= spaceRight;
+    const style: React.CSSProperties = {
+      minWidth: naturalListWidth,
+      width: naturalListWidth,
+    };
+    if (fitsOnRight) {
+      style.left = 0;
+      style.right = 'auto';
+    } else {
+      style.right = 0;
+      style.left = 'auto';
+    }
+    // Clamp width to remaining viewport space so very long option lists don't
+    // overflow in either direction.
+    const maxWidth = fitsOnRight ? spaceRight : spaceLeft;
+    style.maxWidth = Math.max(maxWidth, 160);
+    setListboxStyle(style);
+  }, []);
+
   // Open with the currently-selected option focused so the keyboard user
   // can immediately adjust from their current choice.
   useEffect(() => {
     if (isOpen) setActiveIndex(selectedIndex);
   }, [isOpen, selectedIndex]);
 
-  // Click outside → close
+  // Click outside → close. Also reposition on viewport changes while open.
   useEffect(() => {
     if (!isOpen) return;
     const handleClick = (e: MouseEvent) => {
@@ -99,8 +152,17 @@ export function Dropdown({
       setIsOpen(false);
     };
     document.addEventListener('mousedown', handleClick);
-    return () => document.removeEventListener('mousedown', handleClick);
-  }, [isOpen]);
+    window.addEventListener('resize', measureAndPosition);
+    window.addEventListener('scroll', measureAndPosition, true);
+    // Measure on first paint after open.
+    const id = requestAnimationFrame(measureAndPosition);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      window.removeEventListener('resize', measureAndPosition);
+      window.removeEventListener('scroll', measureAndPosition, true);
+      cancelAnimationFrame(id);
+    };
+  }, [isOpen, measureAndPosition]);
 
   // Scroll active option into view
   useEffect(() => {
@@ -234,7 +296,8 @@ export function Dropdown({
             activeIndex >= 0 ? `${listboxId}-opt-${activeIndex}` : undefined
           }
           aria-label={ariaLabel}
-          className="absolute z-50 mt-1.5 w-full overflow-auto rounded-lg border border-border-primary bg-surface-primary shadow-lg
+          style={listboxStyle}
+          className="absolute z-50 mt-1.5 overflow-auto rounded-lg border border-border-primary bg-surface-primary shadow-lg
                      max-h-60 py-1 animate-fade-in-up outline-none"
         >
           {options.map((option, index) => {
@@ -252,10 +315,10 @@ export function Dropdown({
                 }}
                 onMouseEnter={() => setActiveIndex(index)}
                 onClick={() => selectIndex(index)}
-                className={`flex items-center gap-2 px-3 py-2 text-sm cursor-pointer select-none transition-colors
+                className={`flex items-center gap-2 px-3 py-2 text-sm cursor-pointer select-none transition-colors whitespace-nowrap
                   ${isActive ? 'bg-accent-primary/10 text-text-primary' : 'text-text-secondary hover:bg-surface-secondary hover:text-text-primary'}`}
               >
-                <span className="flex-1 truncate">{option.label}</span>
+                <span data-option-text className="whitespace-nowrap">{option.label}</span>
                 {isSelected && (
                   <Check
                     className="shrink-0 size-4 text-accent-primary"

--- a/src/components/ui/Dropdown.tsx
+++ b/src/components/ui/Dropdown.tsx
@@ -73,7 +73,7 @@ export function Dropdown({
 
   // Anchoring for the listbox. The listbox sizes to its content (w-max) and
   // attaches to the left or right edge of the trigger depending on which side
-  // has more room. Re-measured on every open so it survives resize/scroll.
+  // has more room. Re-measured on every open so it survives resize.
   const [listboxStyle, setListboxStyle] = useState<React.CSSProperties>({
     minWidth: 'max-content',
   });
@@ -153,13 +153,15 @@ export function Dropdown({
     };
     document.addEventListener('mousedown', handleClick);
     window.addEventListener('resize', measureAndPosition);
-    window.addEventListener('scroll', measureAndPosition, true);
+    // The listbox is absolutely positioned relative to the trigger's
+    // `relative` parent, so it scrolls with the trigger — no repositioning
+    // is needed on scroll. Only viewport resizes change the anchor
+    // geometry, so we listen for resize alone.
     // Measure on first paint after open.
     const id = requestAnimationFrame(measureAndPosition);
     return () => {
       document.removeEventListener('mousedown', handleClick);
       window.removeEventListener('resize', measureAndPosition);
-      window.removeEventListener('scroll', measureAndPosition, true);
       cancelAnimationFrame(id);
     };
   }, [isOpen, measureAndPosition]);

--- a/src/lib/filterDeckCards.ts
+++ b/src/lib/filterDeckCards.ts
@@ -1,4 +1,4 @@
-import type { MemoryStage } from "@/lib/memoryStage";
+import { getMemoryStage, type MemoryStage } from "@/lib/memoryStage";
 
 // ── Filter option types ─────────────────────────────────────────────────────
 
@@ -49,13 +49,6 @@ function toMs(value: string | number | Date): number {
   return Number.isNaN(parsed) ? 0 : parsed;
 }
 
-function getStage(repetitions: number): MemoryStage {
-  if (repetitions === 0) return "New";
-  if (repetitions <= 2) return "Learning";
-  if (repetitions <= 5) return "Reviewing";
-  return "Mastered";
-}
-
 /**
  * Filter and sort a deck's cards in-memory. Pure: no IO, no globals. All
  * time-dependent comparisons are parameterized via `now` and
@@ -88,7 +81,7 @@ export function filterDeckCards(
     }
 
     if (opts.stageFilter !== "all") {
-      if (getStage(card.repetitions) !== opts.stageFilter) continue;
+      if (getMemoryStage(card.repetitions) !== opts.stageFilter) continue;
     }
 
     if (opts.dueFilter !== "all") {

--- a/src/lib/filterDeckCards.ts
+++ b/src/lib/filterDeckCards.ts
@@ -1,0 +1,143 @@
+import type { MemoryStage } from "@/lib/memoryStage";
+
+// ── Filter option types ─────────────────────────────────────────────────────
+
+export type StageFilter = MemoryStage | "all";
+export type DueFilter = "all" | "overdue" | "today" | "upcoming";
+export type CardSortKey = "oldest" | "newest" | "due" | "stage";
+
+export interface FilterDeckCardsOptions {
+  query: string;
+  stageFilter: StageFilter;
+  dueFilter: DueFilter;
+  sortKey: CardSortKey;
+  /** Current time in ms. Pass Date.now() from callers; fixed in tests. */
+  now: number;
+  /** Start-of-today in ms (midnight in the user's tz). Fixed in tests. */
+  startOfTodayMs: number;
+}
+
+// ── Input type ───────────────────────────────────────────────────────────────
+// Accepts the shape that comes back from the /api/decks/:id endpoint (string
+// dates from JSON) plus the raw Drizzle row (Date objects) by normalizing both
+// to epoch ms internally. Keeps the function usable from any caller.
+
+export interface DeckCardInput {
+  id: number;
+  front: string;
+  back: string;
+  repetitions: number;
+  nextReview: string | number | Date;
+  createdAt: string | number | Date;
+}
+
+export interface DeckCardOutput {
+  id: number;
+  front: string;
+  back: string;
+  repetitions: number;
+  nextReviewMs: number;
+  createdAtMs: number;
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function toMs(value: string | number | Date): number {
+  if (typeof value === "number") return value;
+  if (value instanceof Date) return value.getTime();
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function getStage(repetitions: number): MemoryStage {
+  if (repetitions === 0) return "New";
+  if (repetitions <= 2) return "Learning";
+  if (repetitions <= 5) return "Reviewing";
+  return "Mastered";
+}
+
+/**
+ * Filter and sort a deck's cards in-memory. Pure: no IO, no globals. All
+ * time-dependent comparisons are parameterized via `now` and
+ * `startOfTodayMs` so the function is deterministic under test.
+ *
+ * Due-status buckets:
+ *   - overdue:  nextReview < startOfTodayMs
+ *   - today:    startOfTodayMs <= nextReview < startOfTodayMs + 1 day
+ *   - upcoming: nextReview >= startOfTodayMs + 1 day
+ */
+export function filterDeckCards(
+  cards: DeckCardInput[],
+  opts: FilterDeckCardsOptions
+): DeckCardOutput[] {
+  const trimmedQuery = opts.query.trim().toLowerCase();
+  const tomorrowMs = opts.startOfTodayMs + MS_PER_DAY;
+
+  const out: DeckCardOutput[] = [];
+
+  for (const card of cards) {
+    const nextReviewMs = toMs(card.nextReview);
+    const createdAtMs = toMs(card.createdAt);
+
+    if (trimmedQuery.length >= 2) {
+      const front = card.front.toLowerCase();
+      const back = card.back.toLowerCase();
+      if (!front.includes(trimmedQuery) && !back.includes(trimmedQuery)) {
+        continue;
+      }
+    }
+
+    if (opts.stageFilter !== "all") {
+      if (getStage(card.repetitions) !== opts.stageFilter) continue;
+    }
+
+    if (opts.dueFilter !== "all") {
+      if (opts.dueFilter === "overdue" && nextReviewMs >= opts.startOfTodayMs) continue;
+      if (opts.dueFilter === "today" && (nextReviewMs < opts.startOfTodayMs || nextReviewMs >= tomorrowMs)) continue;
+      if (opts.dueFilter === "upcoming" && nextReviewMs < tomorrowMs) continue;
+    }
+
+    out.push({
+      id: card.id,
+      front: card.front,
+      back: card.back,
+      repetitions: card.repetitions,
+      nextReviewMs,
+      createdAtMs,
+    });
+  }
+
+  switch (opts.sortKey) {
+    case "newest":
+      out.sort((a, b) => b.id - a.id);
+      break;
+    case "due":
+      out.sort((a, b) => a.nextReviewMs - b.nextReviewMs);
+      break;
+    case "stage":
+      out.sort((a, b) => a.repetitions - b.repetitions || a.id - b.id);
+      break;
+    case "oldest":
+    default:
+      out.sort((a, b) => a.id - b.id);
+      break;
+  }
+
+  return out;
+}
+
+/** True when any filter is set away from its default. */
+export function isFilterActive(opts: {
+  query: string;
+  stageFilter: StageFilter;
+  dueFilter: DueFilter;
+  sortKey: CardSortKey;
+}): boolean {
+  return (
+    opts.query.trim().length > 0 ||
+    opts.stageFilter !== "all" ||
+    opts.dueFilter !== "all"
+    // sortKey is not a "filter" — changing it alone doesn't activate the
+    // clear button. The user may always want their preferred sort.
+  );
+}

--- a/src/lib/startOfToday.ts
+++ b/src/lib/startOfToday.ts
@@ -1,0 +1,30 @@
+/**
+ * Returns the UTC epoch ms of midnight (00:00) at the start of today in
+ * the given IANA timezone. Mirrors the server-side
+ * `getStartOfTodayInTimezone` in `src/server/queries/stats.ts` so the
+ * client's "due today" filter agrees with the dashboard stats.
+ *
+ * Strategy: format the current instant in the target tz with hour/min/sec,
+ * compute ms-since-midnight in that tz, and subtract from `now`. The Y/M/D
+ * parts are not needed — only the time-of-day offset matters.
+ */
+export function startOfTodayInTimezone(timeZone: string): number {
+  const now = new Date();
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    hour: "numeric",
+    minute: "numeric",
+    second: "numeric",
+    hour12: false,
+  }).formatToParts(now);
+
+  const hour = Number(parts.find((p) => p.type === "hour")?.value ?? "0");
+  const minute = Number(parts.find((p) => p.type === "minute")?.value ?? "0");
+  const second = Number(parts.find((p) => p.type === "second")?.value ?? "0");
+
+  // Wall-clock ms since midnight in the target tz. The "hour" value can
+  // be "24" at midnight with hour12: false in some environments; normalize.
+  const normalizedHour = hour === 24 ? 0 : hour;
+  const msSinceMidnight = (normalizedHour * 3600 + minute * 60 + second) * 1000;
+  return now.getTime() - msSinceMidnight;
+}

--- a/src/lib/useDebounce.ts
+++ b/src/lib/useDebounce.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Returns a debounced copy of `value` that only updates after `delayMs`
+ * has elapsed without a change. Useful for search inputs that shouldn't
+ * run their effect on every keystroke.
+ */
+export function useDebounce<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(id);
+  }, [value, delayMs]);
+  return debounced;
+}

--- a/tests/unit/filterDeckCards.test.ts
+++ b/tests/unit/filterDeckCards.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect } from "vitest";
+import {
+  filterDeckCards,
+  isFilterActive,
+  type DeckCardInput,
+} from "@/lib/filterDeckCards";
+
+const DAY = 24 * 60 * 60 * 1000;
+
+// Fixed reference time for deterministic tests.
+const NOW = Date.UTC(2026, 2, 15, 12, 0, 0); // 2026-03-15 12:00 UTC
+const TODAY_START = Date.UTC(2026, 2, 15, 0, 0, 0); // 2026-03-15 00:00 UTC
+
+function card(overrides: Partial<DeckCardInput> & { id: number }): DeckCardInput {
+  return {
+    front: `front-${overrides.id}`,
+    back: `back-${overrides.id}`,
+    repetitions: 0,
+    nextReview: new Date(NOW).toISOString(),
+    createdAt: new Date(NOW).toISOString(),
+    ...overrides,
+  };
+}
+
+const defaults = {
+  query: "",
+  stageFilter: "all" as const,
+  dueFilter: "all" as const,
+  sortKey: "oldest" as const,
+  now: NOW,
+  startOfTodayMs: TODAY_START,
+};
+
+describe("filterDeckCards", () => {
+  describe("no filters", () => {
+    it("returns all cards in id-asc order by default", () => {
+      const cards = [
+        card({ id: 3 }),
+        card({ id: 1 }),
+        card({ id: 2 }),
+      ];
+      const result = filterDeckCards(cards, defaults);
+      expect(result.map((c) => c.id)).toEqual([1, 2, 3]);
+    });
+
+    it("returns an empty array when given no cards", () => {
+      expect(filterDeckCards([], defaults)).toEqual([]);
+    });
+  });
+
+  describe("text query", () => {
+    it("matches front content case-insensitively", () => {
+      const cards = [
+        card({ id: 1, front: "Hola Mundo", back: "x" }),
+        card({ id: 2, front: "Adios", back: "x" }),
+      ];
+      const result = filterDeckCards(cards, { ...defaults, query: "hola" });
+      expect(result.map((c) => c.id)).toEqual([1]);
+    });
+
+    it("matches back content", () => {
+      const cards = [
+        card({ id: 1, front: "x", back: "Hello World" }),
+        card({ id: 2, front: "x", back: "Goodbye" }),
+      ];
+      const result = filterDeckCards(cards, { ...defaults, query: "world" });
+      expect(result.map((c) => c.id)).toEqual([1]);
+    });
+
+    it("ignores queries shorter than 2 chars", () => {
+      const cards = [card({ id: 1, front: "abc", back: "x" })];
+      const result = filterDeckCards(cards, { ...defaults, query: "a" });
+      expect(result.map((c) => c.id)).toEqual([1]);
+    });
+
+    it("trims and lowercases the query", () => {
+      const cards = [
+        card({ id: 1, front: "Spanish", back: "x" }),
+        card({ id: 2, front: "French", back: "x" }),
+      ];
+      const result = filterDeckCards(cards, { ...defaults, query: "  SPANISH  " });
+      expect(result.map((c) => c.id)).toEqual([1]);
+    });
+
+    it("excludes cards that match neither front nor back", () => {
+      const cards = [
+        card({ id: 1, front: "hola", back: "hello" }),
+        card({ id: 2, front: "adios", back: "goodbye" }),
+      ];
+      const result = filterDeckCards(cards, { ...defaults, query: "quantum" });
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("stage filter", () => {
+    it("filters to New (reps=0)", () => {
+      const cards = [
+        card({ id: 1, repetitions: 0 }),
+        card({ id: 2, repetitions: 1 }),
+        card({ id: 3, repetitions: 6 }),
+      ];
+      const result = filterDeckCards(cards, { ...defaults, stageFilter: "New" });
+      expect(result.map((c) => c.id)).toEqual([1]);
+    });
+
+    it("filters to Learning (reps 1-2)", () => {
+      const cards = [
+        card({ id: 1, repetitions: 0 }),
+        card({ id: 2, repetitions: 1 }),
+        card({ id: 3, repetitions: 2 }),
+        card({ id: 4, repetitions: 3 }),
+      ];
+      const result = filterDeckCards(cards, { ...defaults, stageFilter: "Learning" });
+      expect(result.map((c) => c.id)).toEqual([2, 3]);
+    });
+
+    it("filters to Reviewing (reps 3-5)", () => {
+      const cards = [
+        card({ id: 1, repetitions: 2 }),
+        card({ id: 2, repetitions: 3 }),
+        card({ id: 3, repetitions: 5 }),
+        card({ id: 4, repetitions: 6 }),
+      ];
+      const result = filterDeckCards(cards, { ...defaults, stageFilter: "Reviewing" });
+      expect(result.map((c) => c.id)).toEqual([2, 3]);
+    });
+
+    it("filters to Mastered (reps >= 6)", () => {
+      const cards = [
+        card({ id: 1, repetitions: 5 }),
+        card({ id: 2, repetitions: 6 }),
+        card({ id: 3, repetitions: 100 }),
+      ];
+      const result = filterDeckCards(cards, { ...defaults, stageFilter: "Mastered" });
+      expect(result.map((c) => c.id)).toEqual([2, 3]);
+    });
+  });
+
+  describe("due filter", () => {
+    it("overdue = nextReview < startOfToday", () => {
+      const cards = [
+        card({ id: 1, nextReview: new Date(TODAY_START - DAY).toISOString() }), // yesterday
+        card({ id: 2, nextReview: new Date(TODAY_START).toISOString() }), // exactly midnight today
+        card({ id: 3, nextReview: new Date(TODAY_START + DAY).toISOString() }), // tomorrow
+      ];
+      const result = filterDeckCards(cards, { ...defaults, dueFilter: "overdue" });
+      expect(result.map((c) => c.id)).toEqual([1]);
+    });
+
+    it("today = startOfToday <= nextReview < startOfToday + 1day", () => {
+      const cards = [
+        card({ id: 1, nextReview: new Date(TODAY_START - 1).toISOString() }), // just before midnight
+        card({ id: 2, nextReview: new Date(TODAY_START).toISOString() }), // exactly midnight
+        card({ id: 3, nextReview: new Date(TODAY_START + 5 * 60 * 60 * 1000).toISOString() }), // 5am today
+        card({ id: 4, nextReview: new Date(TODAY_START + DAY).toISOString() }), // tomorrow
+      ];
+      const result = filterDeckCards(cards, { ...defaults, dueFilter: "today" });
+      expect(result.map((c) => c.id)).toEqual([2, 3]);
+    });
+
+    it("upcoming = nextReview >= startOfToday + 1day", () => {
+      const cards = [
+        card({ id: 1, nextReview: new Date(TODAY_START + DAY - 1).toISOString() }), // 1ms before tomorrow
+        card({ id: 2, nextReview: new Date(TODAY_START + DAY).toISOString() }), // exactly tomorrow
+        card({ id: 3, nextReview: new Date(TODAY_START + 7 * DAY).toISOString() }), // next week
+      ];
+      const result = filterDeckCards(cards, { ...defaults, dueFilter: "upcoming" });
+      expect(result.map((c) => c.id)).toEqual([2, 3]);
+    });
+  });
+
+  describe("sort", () => {
+    it("oldest = id asc", () => {
+      const cards = [card({ id: 5 }), card({ id: 1 }), card({ id: 3 })];
+      const result = filterDeckCards(cards, { ...defaults, sortKey: "oldest" });
+      expect(result.map((c) => c.id)).toEqual([1, 3, 5]);
+    });
+
+    it("newest = id desc", () => {
+      const cards = [card({ id: 1 }), card({ id: 5 }), card({ id: 3 })];
+      const result = filterDeckCards(cards, { ...defaults, sortKey: "newest" });
+      expect(result.map((c) => c.id)).toEqual([5, 3, 1]);
+    });
+
+    it("due = nextReview asc", () => {
+      const cards = [
+        card({ id: 1, nextReview: new Date(TODAY_START + 3 * DAY).toISOString() }),
+        card({ id: 2, nextReview: new Date(TODAY_START - DAY).toISOString() }), // overdue
+        card({ id: 3, nextReview: new Date(TODAY_START + DAY).toISOString() }),
+      ];
+      const result = filterDeckCards(cards, { ...defaults, sortKey: "due" });
+      expect(result.map((c) => c.id)).toEqual([2, 3, 1]);
+    });
+
+    it("stage = repetitions asc, ties broken by id asc", () => {
+      const cards = [
+        card({ id: 3, repetitions: 0 }),
+        card({ id: 1, repetitions: 5 }),
+        card({ id: 2, repetitions: 0 }),
+        card({ id: 4, repetitions: 5 }),
+      ];
+      const result = filterDeckCards(cards, { ...defaults, sortKey: "stage" });
+      expect(result.map((c) => c.id)).toEqual([2, 3, 1, 4]);
+    });
+  });
+
+  describe("combined filters", () => {
+    it("text + stage + due narrow together", () => {
+      const cards = [
+        card({ id: 1, front: "hola", back: "hello", repetitions: 0, nextReview: new Date(TODAY_START - DAY).toISOString() }),
+        card({ id: 2, front: "hola mundo", back: "x", repetitions: 1, nextReview: new Date(TODAY_START - DAY).toISOString() }),
+        card({ id: 3, front: "hola", back: "x", repetitions: 0, nextReview: new Date(TODAY_START + 2 * DAY).toISOString() }),
+      ];
+      const result = filterDeckCards(cards, {
+        ...defaults,
+        query: "hola",
+        stageFilter: "New",
+        dueFilter: "overdue",
+      });
+      expect(result.map((c) => c.id)).toEqual([1]);
+    });
+  });
+
+  describe("date input formats", () => {
+    it("accepts Date objects", () => {
+      const cards = [
+        card({
+          id: 1,
+          nextReview: new Date(TODAY_START - DAY),
+          createdAt: new Date(NOW),
+        }),
+      ];
+      const result = filterDeckCards(cards, { ...defaults, dueFilter: "overdue" });
+      expect(result.map((c) => c.id)).toEqual([1]);
+    });
+
+    it("accepts epoch ms numbers", () => {
+      const cards = [
+        card({
+          id: 1,
+          nextReview: TODAY_START - DAY,
+          createdAt: NOW,
+        }),
+      ];
+      const result = filterDeckCards(cards, { ...defaults, dueFilter: "overdue" });
+      expect(result.map((c) => c.id)).toEqual([1]);
+    });
+  });
+});
+
+describe("isFilterActive", () => {
+  it("is false with all defaults", () => {
+    expect(isFilterActive({
+      query: "",
+      stageFilter: "all",
+      dueFilter: "all",
+      sortKey: "newest",
+    })).toBe(false);
+  });
+
+  it("is true when query has text", () => {
+    expect(isFilterActive({
+      query: "hola",
+      stageFilter: "all",
+      dueFilter: "all",
+      sortKey: "oldest",
+    })).toBe(true);
+  });
+
+  it("is true when stage filter is set", () => {
+    expect(isFilterActive({
+      query: "",
+      stageFilter: "Learning",
+      dueFilter: "all",
+      sortKey: "oldest",
+    })).toBe(true);
+  });
+
+  it("is true when due filter is set", () => {
+    expect(isFilterActive({
+      query: "",
+      stageFilter: "all",
+      dueFilter: "today",
+      sortKey: "oldest",
+    })).toBe(true);
+  });
+
+  it("sortKey alone does not activate the clear button", () => {
+    expect(isFilterActive({
+      query: "",
+      stageFilter: "all",
+      dueFilter: "all",
+      sortKey: "due",
+    })).toBe(false);
+  });
+
+  it("ignores whitespace-only query", () => {
+    expect(isFilterActive({
+      query: "   ",
+      stageFilter: "all",
+      dueFilter: "all",
+      sortKey: "oldest",
+    })).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #16.

## Summary

Adds a searchable, filterable card browser to the existing deck detail page () so power users can find and open a specific card quickly without scrolling the whole deck.

## What's new

- **CardBrowserFilters** bar on the deck page with:
  - Text search (front/back, case-insensitive, debounced 200ms)
  - Memory-stage filter (New / Learning / Reviewing / Mastered)
  - Due-status filter (Overdue / Due today / Upcoming)
  - Sort dropdown (Oldest first / Newest first / Due first / Stage)
  - Live result count (`X of Y cards`) and a Clear-filters button
- **Dropdown** UI primitive (`src/components/ui/Dropdown.tsx`) — accessible custom listbox following the WAI-ARIA combobox pattern. Focus stays on the trigger; `aria-activedescendant` tracks the active option. Full keyboard nav (Arrow/Home/End/Enter/Space/Escape). No native `<select>`.
- **filterDeckCards** pure function (`src/lib/filterDeckCards.ts`) — in-memory filter+sort with all time-dependent comparisons parameterized so it's deterministic under test.
- **useDebounce** extracted from `SearchBar` to `src/lib/useDebounce.ts` and shared.
- **startOfTodayInTimezone** client helper mirroring the server's `getStartOfTodayInTimezone` so the 'due today' filter agrees with dashboard stats.
- 27 unit tests for `filterDeckCards`.

## What's reused

- The existing `CardViewerModal` + `CardEditForm` handle view/edit — no new inline editor. When filters are active, the modal walks the **filtered** set (verified: opening a card from a filtered list shows `1 / 1`, not `1 / 3`).
- The existing `CardPreview` tile renders filtered results.
- All design tokens, the existing Tailwind v4 surface/border/text/accent variables. No new colors.

## What's not in this PR

- No `/cards` cross-deck page (out of scope per user direction).
- No tags / tag filter — no tags schema exists; deferred to a separate issue.
- No bulk multi-select / bulk delete (mentioned as future extension in the issue).
- No new backend endpoint, hook, or schema migration — filtering is client-side against cards already loaded by `useDeck`. Bounded by `MAX_CARDS_PER_DECK`.

## Verification

- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test` ✅ (259 tests, including 27 new)
- Visual QA via Playwright MCP at 375px / 1280px:
  - Filter bar renders, dropdowns open/close, keyboard nav works (ArrowDown → Enter selects).
  - Text search filters by front+back, case-insensitive.
  - Memory-stage and due-status filters narrow correctly.
  - 'No cards match these filters' empty state with Clear button.
  - Card viewer modal walks filtered set; changing filters while open closes it cleanly.
  - No horizontal overflow at 375px; dropdown listbox fits within viewport.

Plan: `docs/plans/issue-16-card-browser-with-search.md`