### PR TITLE
Misc UI improvements: tiers, forecast toggle, add-another, no-zoom

### DIFF
--- a/.opencode/skills/frontend/SKILL.md
+++ b/.opencode/skills/frontend/SKILL.md
@@ -98,6 +98,11 @@ Lives in `src/app/globals.css` under `@theme inline` and `@layer base`:
   `--accent-success`, `--accent-warning`, `--accent-error`
 - **Chart**: `--chart-new`, `--chart-learning`, `--chart-reviewing`,
   `--chart-mastered`, `--chart-bar`, `--chart-streak`, `--chart-activity`
+- **Card tier badges**: `--tier-seed`, `--tier-sprout`, `--tier-seedling`,
+  `--tier-sapling`, `--tier-bud`, `--tier-bloom`, `--tier-fruit` — one hue
+  per tier in the 7-step plant progression (Seed → Fruit). Deliberately
+  distinct from the 4 `--chart-*` stage colors so adjacent tiers stay
+  distinguishable at a glance. See `src/components/ui/TierBadge.tsx`.
 - **Borders**: `--border-primary`, `--border-secondary`
 
 All have light + dark variants defined in `:root` and the `.dark` / system

--- a/docs/features.md
+++ b/docs/features.md
@@ -31,12 +31,13 @@ User-facing capabilities.
 
 ## Dashboard and insights
 
-- Memory stages pie chart (New / Learning / Reviewing / Mastered) and review
-  forecast chart with an adjustable horizon: 24h (hourly buckets, anchored at
-  the current hour) or 30d (daily buckets, today + 29 future days; overdue
-  cards roll into today). Header summary reads "N due now · M scheduled in
-  the next <period>" so the current bucket and the whole-horizon total stay
-  distinct.
+- Memory stages chart showing the full 7-tier progression (Seed / Sprout /
+  Seedling / Sapling / Bud / Bloom / Fruit) as a stacked bar with per-tier
+  counts and percentages. Review forecast chart with an adjustable horizon:
+  24h (hourly buckets, anchored at the current hour) or 30d (daily buckets,
+  today + 29 future days; overdue cards roll into today). Header summary
+  reads "N due now · M scheduled in the next <period>" so the current bucket
+  and the whole-horizon total stay distinct.
 - Interval stats (1 week / 1 month / 1 year): sessions, cards reviewed,
   accuracy, and % change vs the previous interval.
 - 90-day activity heatmap and helpful empty states.

--- a/docs/features.md
+++ b/docs/features.md
@@ -7,19 +7,22 @@ User-facing capabilities.
 - Create, edit, and remove decks and cards.
 - View card counts, due counts, and last-studied order on decks.
 - Render card content as Markdown (paragraphs, emphasis, lists, inline code).
-- In-deck card browser with text search (front/back), memory-stage filter
-  (New / Learning / Reviewing / Mastered), due-status filter (Overdue / Due
-  today / Upcoming), and sort (oldest / newest / due first / stage). Filtering
-  is client-side against the loaded deck; the card viewer modal walks the
-  filtered set when filters are active.
-- 7-tier plant-metaphor progression (Seed → Sprout → Seedling → Sapling → Bud
-  → Bloom → Fruit), one tier per `repetitions` value 0-5 and 6+. Each card
-  preview shows a colored tier badge with its `N/7` ordinal; the card viewer
-  info panel shows the tier name + its coarse stage roll-up. The 4-bucket
-  memory-stage filter and dashboard widget remain as a stable roll-up.
-- Add-card flow supports "Save & Add Another" — keeps the modal open, clears
-  the form, refocuses the front textarea, and toasts a per-session counter —
-  for fast batch entry.
+- In-deck card browser with text search (front/back), tier filter
+  (All / Acorn / Sprout / Sapling / Tree / Grove / Forest), due-status filter
+  (Overdue / Due today / Upcoming), and sort (oldest / newest / due first /
+  stage). Filtering is client-side against the loaded deck; the card viewer
+  modal walks the filtered set when filters are active.
+- 6-tier plant-metaphor progression (Acorn → Sprout → Sapling → Tree →
+  Grove → Forest), grouped by SM-2 reality: the early tiers change per review
+  because intervals jump fast there, while the mature tiers each span
+  multiple reps because by then intervals are weeks/months/years. Tier
+  labels, colors, and order are defined once in `src/lib/memoryStage.ts`
+  (`TIER_META`) and consumed by the card badge, dashboard widget, and stage
+  filter so they can never drift apart.
+- Add-card flow: a single Save commits the card, clears the form, and keeps
+  the modal open with the front textarea auto-focused for fast batch entry.
+  A per-session counter in the toast ("Card added · N this session") tracks
+  how many you've added; close the modal (X / Esc / backdrop) when done.
 
 ## Study workflow
 
@@ -31,13 +34,13 @@ User-facing capabilities.
 
 ## Dashboard and insights
 
-- Memory stages chart showing the full 7-tier progression (Seed / Sprout /
-  Seedling / Sapling / Bud / Bloom / Fruit) as a stacked bar with per-tier
-  counts and percentages. Review forecast chart with an adjustable horizon:
-  24h (hourly buckets, anchored at the current hour) or 30d (daily buckets,
-  today + 29 future days; overdue cards roll into today). Header summary
-  reads "N due now · M scheduled in the next <period>" so the current bucket
-  and the whole-horizon total stay distinct.
+- Memory stages chart showing the full 6-tier progression (Acorn / Sprout /
+  Sapling / Tree / Grove / Forest) as a stacked bar with per-tier counts and
+  percentages. Review forecast chart with an adjustable horizon: 24h (hourly
+  buckets, anchored at the current hour) or 30d (daily buckets, today + 29
+  future days; overdue cards roll into today). Header summary reads "N due
+  now · M scheduled in the next <period>" so the current bucket and the
+  whole-horizon total stay distinct.
 - Interval stats (1 week / 1 month / 1 year): sessions, cards reviewed,
   accuracy, and % change vs the previous interval.
 - 90-day activity heatmap and helpful empty states.

--- a/docs/features.md
+++ b/docs/features.md
@@ -12,6 +12,14 @@ User-facing capabilities.
   today / Upcoming), and sort (oldest / newest / due first / stage). Filtering
   is client-side against the loaded deck; the card viewer modal walks the
   filtered set when filters are active.
+- 7-tier plant-metaphor progression (Seed → Sprout → Seedling → Sapling → Bud
+  → Bloom → Fruit), one tier per `repetitions` value 0-5 and 6+. Each card
+  preview shows a colored tier badge with its `N/7` ordinal; the card viewer
+  info panel shows the tier name + its coarse stage roll-up. The 4-bucket
+  memory-stage filter and dashboard widget remain as a stable roll-up.
+- Add-card flow supports "Save & Add Another" — keeps the modal open, clears
+  the form, refocuses the front textarea, and toasts a per-session counter —
+  for fast batch entry.
 
 ## Study workflow
 
@@ -23,8 +31,12 @@ User-facing capabilities.
 
 ## Dashboard and insights
 
-- Memory stages pie chart and 30-day per-day review forecast chart (overdue
-  cards roll into today).
+- Memory stages pie chart (New / Learning / Reviewing / Mastered) and review
+  forecast chart with an adjustable horizon: 24h (hourly buckets, anchored at
+  the current hour) or 30d (daily buckets, today + 29 future days; overdue
+  cards roll into today). Header summary reads "N due now · M scheduled in
+  the next <period>" so the current bucket and the whole-horizon total stay
+  distinct.
 - Interval stats (1 week / 1 month / 1 year): sessions, cards reviewed,
   accuracy, and % change vs the previous interval.
 - 90-day activity heatmap and helpful empty states.
@@ -40,3 +52,7 @@ User-facing capabilities.
 - Sign-out and authenticated route gating.
 - Theme options (light, dark, system).
 - Global search (Cmd/Ctrl+K), toast notifications, and mobile usability improvements.
+- App-like mobile viewport: pinch-zoom is disabled (maximum-scale=1,
+  user-scalable=no) so the experience matches a native app — no accidental
+  zoom when tapping inputs, no double-tap zoom dance. System font scaling
+  still works for users who need larger text.

--- a/src/app/(protected)/decks/[id]/page.tsx
+++ b/src/app/(protected)/decks/[id]/page.tsx
@@ -9,7 +9,7 @@ import { filterDeckCards, type CardSortKey, type DueFilter, type StageFilter } f
 import { startOfTodayInTimezone } from '@/lib/startOfToday';
 import { Modal } from '@/components/ui/Modal';
 import { useToast } from '@/components/ui/Toast';
-import { getMemoryStage, getCardTier } from '@/lib/memoryStage';
+import { getCardTier } from '@/lib/memoryStage';
 import { AppHeader } from '@/components/layout/AppHeader';
 import { PageLoader } from '@/components/ui/PageLoader';
 import { MemoryStagesWidget } from '@/components/features/dashboard/MemoryStagesWidget';
@@ -256,26 +256,11 @@ export default function DeckDetailPage() {
         }
     };
 
-    const handleAddCard = async () => {
-        if (addForm.front.trim() && addForm.back.trim()) {
-            try {
-                await addCardMutation.mutateAsync({
-                    front: addForm.front.trim(),
-                    back: addForm.back.trim(),
-                });
-                toast.success('Card added');
-                setAddForm({ front: '', back: '' });
-                setIsAddModalOpen(false);
-            } catch (err) {
-                toast.error(err instanceof Error ? err.message : 'Failed to add card');
-            }
-        }
-    };
-
     // Save the current card, clear the form, and keep the modal open so the
     // user can immediately add another. The form remounts via `key` (see the
-    // Modal JSX) so autoFocus re-triggers on the cleared front textarea.
-    const handleAddCardAndAnother = async () => {
+    // Modal JSX) so autoFocus re-triggers on the cleared front textarea. The
+    // X (or Esc / backdrop) closes the modal when the user is done.
+    const handleAddCard = async () => {
         if (addForm.front.trim() && addForm.back.trim()) {
             try {
                 await addCardMutation.mutateAsync({
@@ -581,7 +566,6 @@ export default function DeckDetailPage() {
                         const infoCard = viewerCards[safeInfoIndex];
                         const reps = infoCard.repetitions;
                         const tier = getCardTier(reps);
-                        const stage = getMemoryStage(reps);
                         const nextReviewMs = new Date(infoCard.nextReview).getTime();
                         const nextReviewLabel =
                             nextReviewMs <= now
@@ -592,7 +576,6 @@ export default function DeckDetailPage() {
                                 <div>
                                     <h3 className="text-xs font-medium text-text-tertiary uppercase tracking-wider mb-2">Tier</h3>
                                     <TierBadge tier={tier} variant="chip" />
-                                    <p className="text-xs text-text-tertiary mt-2">{stage} stage</p>
                                 </div>
                                 <div>
                                     <h3 className="text-xs font-medium text-text-tertiary uppercase tracking-wider mb-1">Next review</h3>
@@ -619,11 +602,8 @@ export default function DeckDetailPage() {
                     back={addForm.back}
                     onFrontChange={(v) => setAddForm((f) => ({ ...f, front: v }))}
                     onBackChange={(v) => setAddForm((f) => ({ ...f, back: v }))}
-                    onCancel={closeAddModal}
                     onSave={handleAddCard}
-                    saveLabel="Save & Close"
-                    onSaveAndAddAnother={handleAddCardAndAnother}
-                    saveAndAddAnotherLabel="Save & Add Another"
+                    saveLabel="Save"
                     autoFocus
                     saving={addCardMutation.isPending}
                 />

--- a/src/app/(protected)/decks/[id]/page.tsx
+++ b/src/app/(protected)/decks/[id]/page.tsx
@@ -57,6 +57,11 @@ export default function DeckDetailPage() {
     const [deckDescription, setDeckDescription] = useState('');
     const [isAddModalOpen, setIsAddModalOpen] = useState(false);
     const [addForm, setAddForm] = useState<CardFormData>({ front: '', back: '' });
+    // Tracks how many cards have been added in the current add-card session
+    // (reset to 0 when the modal closes). Used for the toast counter and to
+    // force the form to remount via `key` so autoFocus re-triggers after a
+    // save-and-add-another.
+    const [addCount, setAddCount] = useState(0);
     const [isDeleteDeckModalOpen, setIsDeleteDeckModalOpen] = useState(false);
     const [isDeleteCardModalOpen, setIsDeleteCardModalOpen] = useState(false);
     const [cardToDeleteId, setCardToDeleteId] = useState<number | null>(null);
@@ -267,6 +272,25 @@ export default function DeckDetailPage() {
         }
     };
 
+    // Save the current card, clear the form, and keep the modal open so the
+    // user can immediately add another. The form remounts via `key` (see the
+    // Modal JSX) so autoFocus re-triggers on the cleared front textarea.
+    const handleAddCardAndAnother = async () => {
+        if (addForm.front.trim() && addForm.back.trim()) {
+            try {
+                await addCardMutation.mutateAsync({
+                    front: addForm.front.trim(),
+                    back: addForm.back.trim(),
+                });
+                setAddCount((n) => n + 1);
+                toast.success(`Card added · ${addCount + 1} this session`);
+                setAddForm({ front: '', back: '' });
+            } catch (err) {
+                toast.error(err instanceof Error ? err.message : 'Failed to add card');
+            }
+        }
+    };
+
     const handleEditCard = async (card: Card, front: string, back: string) => {
         if (front.trim() && back.trim()) {
             try {
@@ -318,6 +342,7 @@ export default function DeckDetailPage() {
     const closeAddModal = () => {
         setIsAddModalOpen(false);
         setAddForm({ front: '', back: '' });
+        setAddCount(0);
     };
 
     return (
@@ -587,15 +612,18 @@ export default function DeckDetailPage() {
             />
 
             {/* Add Card Modal */}
-            <Modal isOpen={isAddModalOpen} onClose={closeAddModal} title="Add New Card" size="lg">
+            <Modal isOpen={isAddModalOpen} onClose={closeAddModal} title="Add Card" size="lg">
                 <CardEditForm
+                    key={`add-${addCount}`}
                     front={addForm.front}
                     back={addForm.back}
                     onFrontChange={(v) => setAddForm((f) => ({ ...f, front: v }))}
                     onBackChange={(v) => setAddForm((f) => ({ ...f, back: v }))}
                     onCancel={closeAddModal}
                     onSave={handleAddCard}
-                    saveLabel="Add Card"
+                    saveLabel="Save & Close"
+                    onSaveAndAddAnother={handleAddCardAndAnother}
+                    saveAndAddAnotherLabel="Save & Add Another"
                     autoFocus
                     saving={addCardMutation.isPending}
                 />

--- a/src/app/(protected)/decks/[id]/page.tsx
+++ b/src/app/(protected)/decks/[id]/page.tsx
@@ -9,7 +9,7 @@ import { filterDeckCards, type CardSortKey, type DueFilter, type StageFilter } f
 import { startOfTodayInTimezone } from '@/lib/startOfToday';
 import { Modal } from '@/components/ui/Modal';
 import { useToast } from '@/components/ui/Toast';
-import { getMemoryStage } from '@/lib/memoryStage';
+import { getMemoryStage, getCardTier } from '@/lib/memoryStage';
 import { AppHeader } from '@/components/layout/AppHeader';
 import { PageLoader } from '@/components/ui/PageLoader';
 import { MemoryStagesWidget } from '@/components/features/dashboard/MemoryStagesWidget';
@@ -20,6 +20,7 @@ import { CardViewerModal } from '@/components/features/decks/CardViewerModal';
 import { CardEditForm } from '@/components/features/decks/CardEditForm';
 import { CardBrowserFilters } from '@/components/features/decks/CardBrowserFilters';
 import { ExportDeckButton } from '@/components/features/decks/ExportDeckButton';
+import { TierBadge } from '@/components/ui/TierBadge';
 import Link from 'next/link';
 
 interface CardFormData {
@@ -512,6 +513,7 @@ export default function DeckDetailPage() {
                                                     key={card.id}
                                                     front={card.front}
                                                     index={gridIndex}
+                                                    repetitions={card.repetitions}
                                                     onClick={() => {
                                                         setViewingCardId(card.id);
                                                         setShowingCardInfo(false);
@@ -546,6 +548,7 @@ export default function DeckDetailPage() {
                         const safeInfoIndex = Math.min(infoCardIndex, viewerCards.length - 1);
                         const infoCard = viewerCards[safeInfoIndex];
                         const reps = infoCard.repetitions;
+                        const tier = getCardTier(reps);
                         const stage = getMemoryStage(reps);
                         const nextReviewMs = new Date(infoCard.nextReview).getTime();
                         const nextReviewLabel =
@@ -555,8 +558,9 @@ export default function DeckDetailPage() {
                         return (
                             <div className="space-y-6">
                                 <div>
-                                    <h3 className="text-xs font-medium text-text-tertiary uppercase tracking-wider mb-1">Memory stage</h3>
-                                    <p className="text-text-primary font-medium">{stage}</p>
+                                    <h3 className="text-xs font-medium text-text-tertiary uppercase tracking-wider mb-2">Tier</h3>
+                                    <TierBadge tier={tier} variant="chip" />
+                                    <p className="text-xs text-text-tertiary mt-2">{stage} stage</p>
                                 </div>
                                 <div>
                                     <h3 className="text-xs font-medium text-text-tertiary uppercase tracking-wider mb-1">Next review</h3>

--- a/src/app/(protected)/decks/[id]/page.tsx
+++ b/src/app/(protected)/decks/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useParams, useRouter } from 'next/navigation';
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { Pencil, Trash2, Plus, Layers } from 'lucide-react';
-import { useDeck, useDeckStats, useDeckIntervalStats, useUpdateDeck, useDeleteDeck, useCreateCard, useUpdateCard, useDeleteCard, type Card } from '@/lib/hooks';
+import { useDeck, useDeckStats, useDeckIntervalStats, useUpdateDeck, useDeleteDeck, useCreateCard, useUpdateCard, useDeleteCard, type Card, type ForecastHorizon } from '@/lib/hooks';
 import { useDebounce } from '@/lib/useDebounce';
 import { filterDeckCards, type CardSortKey, type DueFilter, type StageFilter } from '@/lib/filterDeckCards';
 import { startOfTodayInTimezone } from '@/lib/startOfToday';
@@ -40,8 +40,10 @@ export default function DeckDetailPage() {
 
     const { toast } = useToast();
 
+    const [forecastHorizon, setForecastHorizon] = useState<ForecastHorizon>('30d');
+
     const { data: deckWithCards, isLoading } = useDeck(deckId);
-    const { data: deckStats } = useDeckStats(deckId, timeZone);
+    const { data: deckStats } = useDeckStats(deckId, timeZone, forecastHorizon);
     const { data: deckIntervals } = useDeckIntervalStats(deckId, timeZone);
     const updateDeckMutation = useUpdateDeck(deckId);
     const deleteDeckMutation = useDeleteDeck();
@@ -433,7 +435,12 @@ export default function DeckDetailPage() {
                     {deckStats ? (
                         <>
                             <MemoryStagesWidget data={deckStats.memoryStages} />
-                            <ReviewForecastWidget data={deckStats.reviewForecast} timeZone={timeZone} />
+                            <ReviewForecastWidget
+                                data={deckStats.reviewForecast}
+                                timeZone={timeZone}
+                                horizon={forecastHorizon}
+                                onHorizonChange={setForecastHorizon}
+                            />
                         </>
                     ) : (
                         <>

--- a/src/app/api/decks/[id]/stats/route.ts
+++ b/src/app/api/decks/[id]/stats/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { requireAuthUserId } from "@/server/auth";
-import { deckStats } from "@/server/queries/stats";
+import { deckStats, normalizeHorizon } from "@/server/queries/stats";
 import { badRequest, notFound, parseIdParam, unauthorized } from "@/server/api";
 
 export async function GET(
@@ -11,10 +11,12 @@ export async function GET(
   if (userId === null) return unauthorized();
   const deckId = parseIdParam((await params).id);
   if (deckId === null) return badRequest("Invalid deck id");
+  const url = new URL(req.url);
   const timeZone =
-    new URL(req.url).searchParams.get("tz") ??
+    url.searchParams.get("tz") ??
     Intl.DateTimeFormat().resolvedOptions().timeZone;
-  const stats = await deckStats(userId, deckId, timeZone);
+  const horizon = normalizeHorizon(url.searchParams.get("horizon"));
+  const stats = await deckStats(userId, deckId, timeZone, horizon);
   if (!stats) return notFound("Deck not found");
   return NextResponse.json(stats);
 }

--- a/src/app/api/stats/dashboard/route.ts
+++ b/src/app/api/stats/dashboard/route.ts
@@ -1,14 +1,16 @@
 import { NextResponse } from "next/server";
 import { requireAuthUserId } from "@/server/auth";
-import { dashboardStats } from "@/server/queries/stats";
+import { dashboardStats, normalizeHorizon } from "@/server/queries/stats";
 import { unauthorized } from "@/server/api";
 
 export async function GET(req: Request): Promise<NextResponse> {
   const userId = await requireAuthUserId().catch(() => null);
   if (userId === null) return unauthorized();
+  const url = new URL(req.url);
   const timeZone =
-    new URL(req.url).searchParams.get("tz") ??
+    url.searchParams.get("tz") ??
     Intl.DateTimeFormat().resolvedOptions().timeZone;
-  const stats = await dashboardStats(userId, timeZone);
+  const horizon = normalizeHorizon(url.searchParams.get("horizon"));
+  const stats = await dashboardStats(userId, timeZone, horizon);
   return NextResponse.json(stats);
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -56,18 +56,16 @@
   --chart-streak: #f59e0b;
   --chart-activity: #3b82f6;
 
-  /* Card tier badge colors — 7-step plant progression (Seed → Fruit).
-     Deliberately not derived from the 4 chart-* tokens: the badges need a
-     distinct hue per tier so adjacent levels stay distinguishable at a
-     glance. The first four echo the coarse stage colors so the dashboard
-     bar and the badges don't clash. */
-  --tier-seed: #94a3b8;
-  --tier-sprout: #3b82f6;
-  --tier-seedling: #f59e0b;
-  --tier-sapling: #8b5cf6;
-  --tier-bud: #ec4899;
-  --tier-bloom: #10b981;
-  --tier-fruit: #f59e0b;
+  /* Card tier badge colors — 6-step forest progression (Acorn → Forest).
+     Brown for the unreviewed acorn (it isn't green yet), then a clear
+     lightness ramp through greens so adjacent tiers stay distinguishable
+     at a glance. Kept light enough to read against the light surface. */
+  --tier-acorn: #ca8a04;
+  --tier-sprout: #a3e635;
+  --tier-sapling: #65a30d;
+  --tier-tree: #16a34a;
+  --tier-grove: #15803d;
+  --tier-forest: #166534;
 
   /* Shadow */
   --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
@@ -131,13 +129,12 @@
   --chart-activity: #60a5fa;
 
   /* Card tier badge colors — slightly softer in dark mode */
-  --tier-seed: #94a3b8;
-  --tier-sprout: #60a5fa;
-  --tier-seedling: #fbbf24;
-  --tier-sapling: #a78bfa;
-  --tier-bud: #f472b6;
-  --tier-bloom: #34d399;
-  --tier-fruit: #fbbf24;
+  --tier-acorn: #d97706;
+  --tier-sprout: #bef264;
+  --tier-sapling: #4ade80;
+  --tier-tree: #22c55e;
+  --tier-grove: #16a34a;
+  --tier-forest: #14532d;
 
   /* Shadow */
   --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.3);
@@ -202,13 +199,12 @@
     --chart-activity: #60a5fa;
 
     /* Card tier badge colors — slightly softer in dark mode */
-    --tier-seed: #94a3b8;
-    --tier-sprout: #60a5fa;
-    --tier-seedling: #fbbf24;
-    --tier-sapling: #a78bfa;
-    --tier-bud: #f472b6;
-    --tier-bloom: #34d399;
-    --tier-fruit: #fbbf24;
+    --tier-acorn: #d97706;
+    --tier-sprout: #bef264;
+    --tier-sapling: #4ade80;
+    --tier-tree: #22c55e;
+    --tier-grove: #16a34a;
+    --tier-forest: #14532d;
 
     /* Shadow */
     --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.3);
@@ -252,13 +248,12 @@
   --color-status-close-bg: var(--status-close-bg);
   --color-status-close-border: var(--status-close-border);
   --color-status-close-text: var(--status-close-text);
-  --color-tier-seed: var(--tier-seed);
+  --color-tier-acorn: var(--tier-acorn);
   --color-tier-sprout: var(--tier-sprout);
-  --color-tier-seedling: var(--tier-seedling);
   --color-tier-sapling: var(--tier-sapling);
-  --color-tier-bud: var(--tier-bud);
-  --color-tier-bloom: var(--tier-bloom);
-  --color-tier-fruit: var(--tier-fruit);
+  --color-tier-tree: var(--tier-tree);
+  --color-tier-grove: var(--tier-grove);
+  --color-tier-forest: var(--tier-forest);
   --shadow-sm: var(--shadow-sm);
   --shadow-md: var(--shadow-md);
   --shadow-lg: var(--shadow-lg);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -56,6 +56,19 @@
   --chart-streak: #f59e0b;
   --chart-activity: #3b82f6;
 
+  /* Card tier badge colors — 7-step plant progression (Seed → Fruit).
+     Deliberately not derived from the 4 chart-* tokens: the badges need a
+     distinct hue per tier so adjacent levels stay distinguishable at a
+     glance. The first four echo the coarse stage colors so the dashboard
+     bar and the badges don't clash. */
+  --tier-seed: #94a3b8;
+  --tier-sprout: #3b82f6;
+  --tier-seedling: #f59e0b;
+  --tier-sapling: #8b5cf6;
+  --tier-bud: #ec4899;
+  --tier-bloom: #10b981;
+  --tier-fruit: #f59e0b;
+
   /* Shadow */
   --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
   --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
@@ -116,6 +129,15 @@
   --chart-bar: #60a5fa;
   --chart-streak: #fbbf24;
   --chart-activity: #60a5fa;
+
+  /* Card tier badge colors — slightly softer in dark mode */
+  --tier-seed: #94a3b8;
+  --tier-sprout: #60a5fa;
+  --tier-seedling: #fbbf24;
+  --tier-sapling: #a78bfa;
+  --tier-bud: #f472b6;
+  --tier-bloom: #34d399;
+  --tier-fruit: #fbbf24;
 
   /* Shadow */
   --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.3);
@@ -179,6 +201,15 @@
     --chart-streak: #fbbf24;
     --chart-activity: #60a5fa;
 
+    /* Card tier badge colors — slightly softer in dark mode */
+    --tier-seed: #94a3b8;
+    --tier-sprout: #60a5fa;
+    --tier-seedling: #fbbf24;
+    --tier-sapling: #a78bfa;
+    --tier-bud: #f472b6;
+    --tier-bloom: #34d399;
+    --tier-fruit: #fbbf24;
+
     /* Shadow */
     --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.3);
     --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.4), 0 2px 4px -2px rgb(0 0 0 / 0.4);
@@ -221,6 +252,13 @@
   --color-status-close-bg: var(--status-close-bg);
   --color-status-close-border: var(--status-close-border);
   --color-status-close-text: var(--status-close-text);
+  --color-tier-seed: var(--tier-seed);
+  --color-tier-sprout: var(--tier-sprout);
+  --color-tier-seedling: var(--tier-seedling);
+  --color-tier-sapling: var(--tier-sapling);
+  --color-tier-bud: var(--tier-bud);
+  --color-tier-bloom: var(--tier-bloom);
+  --color-tier-fruit: var(--tier-fruit);
   --shadow-sm: var(--shadow-sm);
   --shadow-md: var(--shadow-md);
   --shadow-lg: var(--shadow-lg);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { ThemeProvider } from "../components/theme/ThemeProvider";
@@ -19,6 +19,16 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: "Flashcards App",
   description: "Create and study flashcards",
+};
+
+// App-like viewport: disables pinch-zoom on mobile so the experience matches
+// a native app (no accidental zoom when tapping a textarea, no double-tap
+// zoom dance). Users who need larger text can still use system font scaling.
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
 };
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,7 +10,7 @@ import { ReviewForecastWidget } from "@/components/features/dashboard/ReviewFore
 import { IntervalStatsWidget } from "@/components/features/dashboard/IntervalStatsWidget";
 import { ActivityHeatmapWidget } from "@/components/features/dashboard/ActivityHeatmapWidget";
 import { HeroCTAWidget } from "@/components/features/dashboard/HeroCTAWidget";
-import { useDashboardStats, useIntervalStats, useActivityHistory, useRegistrationOpen } from "@/lib/hooks";
+import { useDashboardStats, useIntervalStats, useActivityHistory, useRegistrationOpen, type ForecastHorizon } from "@/lib/hooks";
 import { api, ApiError } from "@/lib/api";
 
 function AuthenticatedContent() {
@@ -18,7 +18,8 @@ function AuthenticatedContent() {
     typeof Intl !== "undefined"
       ? Intl.DateTimeFormat().resolvedOptions().timeZone
       : "UTC";
-  const { data: stats } = useDashboardStats(timeZone);
+  const [forecastHorizon, setForecastHorizon] = useState<ForecastHorizon>("30d");
+  const { data: stats } = useDashboardStats(timeZone, forecastHorizon);
   const { data: intervals } = useIntervalStats(timeZone);
   const { data: activity } = useActivityHistory(timeZone);
 
@@ -36,7 +37,12 @@ function AuthenticatedContent() {
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
           <div className="lg:col-span-2 flex flex-col gap-6">
             {stats && (
-              <ReviewForecastWidget data={stats.reviewForecast} timeZone={timeZone} />
+              <ReviewForecastWidget
+                data={stats.reviewForecast}
+                timeZone={timeZone}
+                horizon={forecastHorizon}
+                onHorizonChange={setForecastHorizon}
+              />
             )}
             {activity && (
               <ActivityHeatmapWidget data={activity} timeZone={timeZone} />

--- a/src/components/features/dashboard/ActivityHeatmapWidget.tsx
+++ b/src/components/features/dashboard/ActivityHeatmapWidget.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
+
 import {
   buildHeatmapDays,
   groupIntoWeeks,
@@ -33,6 +35,13 @@ export function ActivityHeatmapWidget({ data, timeZone }: ActivityHeatmapWidgetP
   const monthLabels = computeMonthLabels(weeks);
   const totalCards = Object.values(data).reduce((sum, c) => sum + c, 0);
 
+  const scrollRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollLeft = scrollRef.current.scrollWidth;
+    }
+  }, [weeks.length]);
+
   return (
     <div className="rounded-xl border border-border-primary bg-surface-primary p-5 shadow-sm">
       <div className="flex items-center justify-between mb-3">
@@ -44,7 +53,7 @@ export function ActivityHeatmapWidget({ data, timeZone }: ActivityHeatmapWidgetP
         </span>
       </div>
 
-      <div className="overflow-x-auto">
+      <div ref={scrollRef} className="overflow-x-auto">
         <div className="inline-flex flex-col min-w-fit">
           {/* Month labels — offset by weekday label width */}
           <div className="flex mb-1">

--- a/src/components/features/dashboard/MemoryStagesWidget.tsx
+++ b/src/components/features/dashboard/MemoryStagesWidget.tsx
@@ -1,13 +1,12 @@
 'use client';
 
 export interface MemoryStagesData {
-  seed: number;
+  acorn: number;
   sprout: number;
-  seedling: number;
   sapling: number;
-  bud: number;
-  bloom: number;
-  fruit: number;
+  tree: number;
+  grove: number;
+  forest: number;
 }
 
 const STAGE_META: {
@@ -15,13 +14,12 @@ const STAGE_META: {
   label: string;
   color: string;
 }[] = [
-  { key: 'seed', label: 'Seed', color: 'var(--tier-seed)' },
+  { key: 'acorn', label: 'Acorn', color: 'var(--tier-acorn)' },
   { key: 'sprout', label: 'Sprout', color: 'var(--tier-sprout)' },
-  { key: 'seedling', label: 'Seedling', color: 'var(--tier-seedling)' },
   { key: 'sapling', label: 'Sapling', color: 'var(--tier-sapling)' },
-  { key: 'bud', label: 'Bud', color: 'var(--tier-bud)' },
-  { key: 'bloom', label: 'Bloom', color: 'var(--tier-bloom)' },
-  { key: 'fruit', label: 'Fruit', color: 'var(--tier-fruit)' },
+  { key: 'tree', label: 'Tree', color: 'var(--tier-tree)' },
+  { key: 'grove', label: 'Grove', color: 'var(--tier-grove)' },
+  { key: 'forest', label: 'Forest', color: 'var(--tier-forest)' },
 ];
 
 interface MemoryStagesWidgetProps {

--- a/src/components/features/dashboard/MemoryStagesWidget.tsx
+++ b/src/components/features/dashboard/MemoryStagesWidget.tsx
@@ -1,10 +1,13 @@
 'use client';
 
 export interface MemoryStagesData {
-  new: number;
-  learning: number;
-  reviewing: number;
-  mastered: number;
+  seed: number;
+  sprout: number;
+  seedling: number;
+  sapling: number;
+  bud: number;
+  bloom: number;
+  fruit: number;
 }
 
 const STAGE_META: {
@@ -12,10 +15,13 @@ const STAGE_META: {
   label: string;
   color: string;
 }[] = [
-  { key: 'new', label: 'New', color: 'var(--chart-new)' },
-  { key: 'learning', label: 'Learning', color: 'var(--chart-learning)' },
-  { key: 'reviewing', label: 'Reviewing', color: 'var(--chart-reviewing)' },
-  { key: 'mastered', label: 'Mastered', color: 'var(--chart-mastered)' },
+  { key: 'seed', label: 'Seed', color: 'var(--tier-seed)' },
+  { key: 'sprout', label: 'Sprout', color: 'var(--tier-sprout)' },
+  { key: 'seedling', label: 'Seedling', color: 'var(--tier-seedling)' },
+  { key: 'sapling', label: 'Sapling', color: 'var(--tier-sapling)' },
+  { key: 'bud', label: 'Bud', color: 'var(--tier-bud)' },
+  { key: 'bloom', label: 'Bloom', color: 'var(--tier-bloom)' },
+  { key: 'fruit', label: 'Fruit', color: 'var(--tier-fruit)' },
 ];
 
 interface MemoryStagesWidgetProps {
@@ -23,8 +29,7 @@ interface MemoryStagesWidgetProps {
 }
 
 export function MemoryStagesWidget({ data }: MemoryStagesWidgetProps) {
-  const total =
-    data.new + data.learning + data.reviewing + data.mastered;
+  const total = STAGE_META.reduce((sum, s) => sum + data[s.key], 0);
 
   if (total === 0) {
     return (

--- a/src/components/features/dashboard/MemoryStagesWidget.tsx
+++ b/src/components/features/dashboard/MemoryStagesWidget.tsx
@@ -1,29 +1,20 @@
 'use client';
 
-export interface MemoryStagesData {
-  acorn: number;
-  sprout: number;
-  sapling: number;
-  tree: number;
-  grove: number;
-  forest: number;
-}
+import { TIER_META } from '@/lib/memoryStage';
+import type { MemoryStages } from '@/lib/hooks';
 
 const STAGE_META: {
-  key: keyof MemoryStagesData;
+  key: keyof MemoryStages;
   label: string;
   color: string;
-}[] = [
-  { key: 'acorn', label: 'Acorn', color: 'var(--tier-acorn)' },
-  { key: 'sprout', label: 'Sprout', color: 'var(--tier-sprout)' },
-  { key: 'sapling', label: 'Sapling', color: 'var(--tier-sapling)' },
-  { key: 'tree', label: 'Tree', color: 'var(--tier-tree)' },
-  { key: 'grove', label: 'Grove', color: 'var(--tier-grove)' },
-  { key: 'forest', label: 'Forest', color: 'var(--tier-forest)' },
-];
+}[] = TIER_META.map((t) => ({
+  key: t.tier.toLowerCase() as keyof MemoryStages,
+  label: t.label,
+  color: t.token,
+}));
 
 interface MemoryStagesWidgetProps {
-  data: MemoryStagesData;
+  data: MemoryStages;
 }
 
 export function MemoryStagesWidget({ data }: MemoryStagesWidgetProps) {

--- a/src/components/features/dashboard/ReviewForecastWidget.tsx
+++ b/src/components/features/dashboard/ReviewForecastWidget.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useRef, KeyboardEvent } from 'react';
 import {
   BarChart,
   Bar,
@@ -9,141 +10,276 @@ import {
   Tooltip,
   Cell,
 } from 'recharts';
+import type { ForecastHorizon } from '@/lib/hooks';
 
-export interface ReviewForecastDay {
+export interface ReviewForecastBucket {
   date: string;
   count: number;
+  bucket: 'hour' | 'day';
 }
 
 interface ReviewForecastWidgetProps {
-  data: ReviewForecastDay[];
+  data: ReviewForecastBucket[];
   timeZone?: string;
+  /** Currently selected horizon. The widget is controlled — the parent owns
+   *  the state so the dashboard and deck pages can persist it independently. */
+  horizon: ForecastHorizon;
+  onHorizonChange: (h: ForecastHorizon) => void;
 }
 
 const BAR_COLOR = 'var(--chart-bar)';
 const TODAY_COLOR = 'var(--accent-primary)';
 
-function formatShortDate(iso: string): string {
+const HORIZON_OPTIONS: ForecastHorizon[] = ['24h', '30d'];
+const HORIZON_LABELS: Record<ForecastHorizon, string> = {
+  '24h': '24h',
+  '30d': '30d',
+};
+
+/**
+ * Format a bucket date for the X-axis.
+ * - Day buckets  → "M/D"  (e.g. 7/21)
+ * - Hour buckets → "HH:00" using the user's timezone (e.g. 14:00)
+ */
+function formatTickLabel(iso: string, bucket: 'hour' | 'day', timeZone: string): string {
+  if (bucket === 'hour') {
+    const d = new Date(iso);
+    return new Intl.DateTimeFormat('en-CA', {
+      timeZone,
+      hour: '2-digit',
+      hour12: false,
+    }).format(d);
+  }
   const d = new Date(`${iso}T00:00:00`);
   return `${d.getMonth() + 1}/${d.getDate()}`;
 }
 
-export function ReviewForecastWidget({ data, timeZone }: ReviewForecastWidgetProps) {
-  const tz = timeZone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
-  const todayKey = new Intl.DateTimeFormat('en-CA', {
-    timeZone: tz,
+function formatTooltipTitle(iso: string, bucket: 'hour' | 'day', timeZone: string): string {
+  const d = new Date(bucket === 'hour' ? iso : `${iso}T00:00:00`);
+  if (bucket === 'hour') {
+    return new Intl.DateTimeFormat('en-CA', {
+      timeZone,
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    }).format(d);
+  }
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  }).format(d);
+}
+
+/**
+ * Identify the "current" bucket — the one to highlight in the accent color
+ * and to count as "due now" in the header summary. For 30d it's today; for
+ * 24h it's the current hour.
+ */
+function currentBucketKey(horizon: ForecastHorizon, timeZone: string): string {
+  if (horizon === '24h') {
+    const parts = new Intl.DateTimeFormat('en-CA', {
+      timeZone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      hour12: false,
+    }).formatToParts(new Date());
+    const year = parts.find((p) => p.type === 'year')?.value ?? '0000';
+    const month = parts.find((p) => p.type === 'month')?.value ?? '01';
+    const day = parts.find((p) => p.type === 'day')?.value ?? '01';
+    let hour = parts.find((p) => p.type === 'hour')?.value ?? '00';
+    if (hour === '24') hour = '00';
+    return `${year}-${month}-${day}T${hour}:00`;
+  }
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone,
     year: 'numeric',
     month: '2-digit',
     day: '2-digit',
   }).format(new Date());
+}
+
+export function ReviewForecastWidget({
+  data,
+  timeZone,
+  horizon,
+  onHorizonChange,
+}: ReviewForecastWidgetProps) {
+  const tz = timeZone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const todayKey = currentBucketKey(horizon, tz);
+  const tabRefs = useRef<Record<ForecastHorizon, HTMLButtonElement | null>>({
+    '24h': null,
+    '30d': null,
+  });
 
   const chartData = data.map((d) => ({
-    label: formatShortDate(d.date),
+    label: formatTickLabel(d.date, d.bucket, tz),
     value: d.count,
     date: d.date,
-    isToday: d.date === todayKey,
+    bucket: d.bucket,
+    isCurrent: d.date === todayKey,
   }));
 
   const totalScheduled = chartData.reduce((sum, d) => sum + d.value, 0);
+  const currentBucket = chartData.find((d) => d.isCurrent);
+  const dueNow = currentBucket?.value ?? 0;
 
-  if (totalScheduled === 0) {
-    return (
-      <div className="rounded-xl border border-border-primary bg-surface-primary p-5 shadow-sm">
-        <h3 className="text-sm font-semibold text-text-primary mb-4">
-          Review forecast · next 30 days
-        </h3>
-        <div className="flex min-h-44 items-center justify-center text-text-tertiary text-sm">
-          No scheduled reviews — study some cards to see your forecast
-        </div>
-      </div>
-    );
-  }
+  // Pick a tick interval that yields ≤ 8 visible ticks across the X-axis so
+  // multi-char labels never collide. For 24 buckets, every 3rd tick fits;
+  // for 30 buckets, every 4th tick (≈ 8 labels) does. The bug fixed here
+  // was `interval={4}` showing only the right-most digit of each label.
+  const tickInterval = horizon === '24h' ? 2 : Math.ceil(chartData.length / 8) - 1;
+
+  const horizonNoun = horizon === '24h' ? '24 hours' : '30 days';
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    const idx = HORIZON_OPTIONS.indexOf(horizon);
+    let nextIdx: number | null = null;
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+      nextIdx = (idx + 1) % HORIZON_OPTIONS.length;
+    } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+      nextIdx = (idx - 1 + HORIZON_OPTIONS.length) % HORIZON_OPTIONS.length;
+    }
+    if (nextIdx === null) return;
+    e.preventDefault();
+    const nextKey = HORIZON_OPTIONS[nextIdx];
+    onHorizonChange(nextKey);
+    tabRefs.current[nextKey]?.focus();
+  };
+
+  const empty = totalScheduled === 0;
 
   return (
     <div className="rounded-xl border border-border-primary bg-surface-primary p-5 shadow-sm">
-      <div className="flex items-center justify-between mb-4">
-        <h3 className="text-sm font-semibold text-text-primary">
-          Review forecast · next 30 days
-        </h3>
-        <span className="text-xs text-text-tertiary">
-          {totalScheduled} card{totalScheduled !== 1 ? 's' : ''} due
-        </span>
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
+        <h3 className="text-sm font-semibold text-text-primary">Review forecast</h3>
+        <div
+          role="tablist"
+          aria-label="Review forecast horizon"
+          className="inline-flex rounded-lg border border-border-primary bg-surface-secondary p-0.5 text-xs"
+          onKeyDown={handleKeyDown}
+        >
+          {HORIZON_OPTIONS.map((key) => {
+            const selected = key === horizon;
+            return (
+              <button
+                key={key}
+                ref={(el) => {
+                  tabRefs.current[key] = el;
+                }}
+                role="tab"
+                type="button"
+                aria-selected={selected}
+                tabIndex={selected ? 0 : -1}
+                onClick={() => onHorizonChange(key)}
+                className={`px-3 py-1 rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-accent-primary ${
+                  selected
+                    ? 'bg-surface-primary text-text-primary shadow-sm'
+                    : 'text-text-secondary hover:text-text-primary'
+                }`}
+              >
+                {HORIZON_LABELS[key]}
+              </button>
+            );
+          })}
+        </div>
       </div>
-      <div className="h-40 sm:h-48 w-full">
-        <ResponsiveContainer width="100%" height="100%">
-          <BarChart
-            data={chartData}
-            margin={{ top: 4, right: 8, left: -24, bottom: 0 }}
-          >
-            <XAxis
-              dataKey="label"
-              interval={4}
-              tick={{
-                fill: 'var(--text-tertiary)',
-                fontSize: 11,
-              }}
-              axisLine={false}
-              tickLine={false}
-            />
-            <YAxis
-              allowDecimals={false}
-              tick={{
-                fill: 'var(--text-tertiary)',
-                fontSize: 11,
-              }}
-              axisLine={false}
-              tickLine={false}
-              width={40}
-            />
-            <Tooltip
-              cursor={{
-                fill: 'var(--surface-tertiary)',
-                fillOpacity: 0.4,
-              }}
-              content={(props) => {
-                const { active, payload } = props;
-                if (!active || !payload?.length) return null;
-                const entry = payload[0]?.payload as
-                  | { date: string; value: number }
-                  | undefined;
-                if (!entry) return null;
-                return (
-                  <div
-                    className="rounded-lg border px-3 py-2 shadow-md"
-                    style={{
-                      backgroundColor: 'var(--surface-primary)',
-                      borderColor: 'var(--border-primary)',
-                      color: 'var(--text-primary)',
-                      fontSize: '0.875rem',
-                    }}
-                  >
-                    <span style={{ color: 'var(--text-secondary)' }}>
-                      {entry.date}:{' '}
-                    </span>
-                    <span style={{ color: 'var(--text-primary)' }}>
-                      {entry.value} card{entry.value !== 1 ? 's' : ''}
-                    </span>
-                  </div>
-                );
-              }}
-            />
-            <Bar
-              dataKey="value"
-              fill={BAR_COLOR}
-              radius={[2, 2, 0, 0]}
-              maxBarSize={24}
-            >
-              {chartData.map((entry) => (
-                <Cell
-                  key={entry.date}
-                  fill={entry.isToday ? TODAY_COLOR : BAR_COLOR}
-                  fillOpacity={entry.isToday ? 1 : 0.85}
+
+      {empty ? (
+        <div className="flex min-h-44 items-center justify-center text-text-tertiary text-sm">
+          No scheduled reviews in the next {horizonNoun}
+        </div>
+      ) : (
+        <>
+          <div className="mb-3 flex items-baseline gap-2 text-xs text-text-tertiary tabular-nums">
+            <span className="font-medium text-text-primary">{dueNow}</span>
+            <span>due now ·</span>
+            <span className="font-medium text-text-secondary">{totalScheduled}</span>
+            <span>scheduled in the next {horizonNoun}</span>
+          </div>
+          <div className="h-40 sm:h-48 w-full">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart
+                data={chartData}
+                margin={{ top: 4, right: 8, left: -24, bottom: 0 }}
+              >
+                <XAxis
+                  dataKey="label"
+                  interval={tickInterval}
+                  tickMargin={8}
+                  tick={{
+                    fill: 'var(--text-tertiary)',
+                    fontSize: 11,
+                  }}
+                  axisLine={false}
+                  tickLine={false}
                 />
-              ))}
-            </Bar>
-          </BarChart>
-        </ResponsiveContainer>
-      </div>
+                <YAxis
+                  allowDecimals={false}
+                  tick={{
+                    fill: 'var(--text-tertiary)',
+                    fontSize: 11,
+                  }}
+                  axisLine={false}
+                  tickLine={false}
+                  width={40}
+                />
+                <Tooltip
+                  cursor={{
+                    fill: 'var(--surface-tertiary)',
+                    fillOpacity: 0.4,
+                  }}
+                  content={(props) => {
+                    const { active, payload } = props;
+                    if (!active || !payload?.length) return null;
+                    const entry = payload[0]?.payload as
+                      | { date: string; value: number; bucket: 'hour' | 'day' }
+                      | undefined;
+                    if (!entry) return null;
+                    return (
+                      <div
+                        className="rounded-lg border px-3 py-2 shadow-md"
+                        style={{
+                          backgroundColor: 'var(--surface-primary)',
+                          borderColor: 'var(--border-primary)',
+                          color: 'var(--text-primary)',
+                          fontSize: '0.875rem',
+                        }}
+                      >
+                        <span style={{ color: 'var(--text-secondary)' }}>
+                          {formatTooltipTitle(entry.date, entry.bucket, tz)}:{' '}
+                        </span>
+                        <span style={{ color: 'var(--text-primary)' }}>
+                          {entry.value} card{entry.value !== 1 ? 's' : ''}
+                        </span>
+                      </div>
+                    );
+                  }}
+                />
+                <Bar
+                  dataKey="value"
+                  fill={BAR_COLOR}
+                  radius={[2, 2, 0, 0]}
+                  maxBarSize={24}
+                >
+                  {chartData.map((entry) => (
+                    <Cell
+                      key={entry.date}
+                      fill={entry.isCurrent ? TODAY_COLOR : BAR_COLOR}
+                      fillOpacity={entry.isCurrent ? 1 : 0.85}
+                    />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/features/dashboard/ReviewForecastWidget.tsx
+++ b/src/components/features/dashboard/ReviewForecastWidget.tsx
@@ -206,7 +206,7 @@ export function ReviewForecastWidget({
             <ResponsiveContainer width="100%" height="100%">
               <BarChart
                 data={chartData}
-                margin={{ top: 4, right: 8, left: -24, bottom: 0 }}
+                margin={{ top: 4, right: 8, left: 0, bottom: 0 }}
               >
                 <XAxis
                   dataKey="label"

--- a/src/components/features/decks/CardBrowserFilters.tsx
+++ b/src/components/features/decks/CardBrowserFilters.tsx
@@ -2,6 +2,7 @@
 
 import { Search, X, Filter, CalendarClock, GraduationCap, ArrowDownUp } from 'lucide-react';
 import { Dropdown, type DropdownOption } from '@/components/ui/Dropdown';
+import { TIER_META } from '@/lib/memoryStage';
 import {
   type CardSortKey,
   type DueFilter,
@@ -29,10 +30,7 @@ export interface CardBrowserFiltersProps {
 
 const STAGE_OPTIONS: DropdownOption[] = [
   { value: 'all', label: 'All stages' },
-  { value: 'New', label: 'New' },
-  { value: 'Learning', label: 'Learning' },
-  { value: 'Reviewing', label: 'Reviewing' },
-  { value: 'Mastered', label: 'Mastered' },
+  ...TIER_META.map((t) => ({ value: t.tier, label: t.label })),
 ];
 
 const DUE_OPTIONS: DropdownOption[] = [

--- a/src/components/features/decks/CardEditForm.tsx
+++ b/src/components/features/decks/CardEditForm.tsx
@@ -1,25 +1,20 @@
 'use client';
 
+import { Check } from 'lucide-react';
+
 interface CardEditFormProps {
   front: string;
   back: string;
   onFrontChange: (value: string) => void;
   onBackChange: (value: string) => void;
-  /** If provided, renders Cancel and a primary action button in the footer. */
+  /** Optional Cancel handler. Renders a secondary button in the footer. */
   onCancel?: () => void;
+  /** Primary Save action. */
   onSave?: () => void;
   saveLabel?: string;
-  /**
-   * Optional secondary action — typically "Save & Add Another" in the
-   * add-card flow. When provided, it renders as the primary button and
-   * `onSave` becomes a secondary "Save & Close" button. The parent is
-   * responsible for clearing the form and refocusing on success.
-   */
-  onSaveAndAddAnother?: () => void;
-  saveAndAddAnotherLabel?: string;
   /** Auto-focus the front textarea on mount. */
   autoFocus?: boolean;
-  /** Disables the save buttons and shows a pending label while true. */
+  /** Disables the save button and shows a pending label while true. */
   saving?: boolean;
 }
 
@@ -33,14 +28,12 @@ export function CardEditForm({
   onBackChange,
   onCancel,
   onSave,
-  saveLabel = 'Save Changes',
-  onSaveAndAddAnother,
-  saveAndAddAnotherLabel = 'Save & Add Another',
+  saveLabel = 'Save',
   autoFocus = false,
   saving = false,
 }: CardEditFormProps) {
   const canSubmit = !front.trim() || !back.trim() || saving;
-  const hasFooter = onCancel || onSave || onSaveAndAddAnother;
+  const hasFooter = onCancel || onSave;
 
   return (
     <div className="flex flex-col gap-4 h-full">
@@ -86,19 +79,10 @@ export function CardEditForm({
               type="button"
               onClick={onSave}
               disabled={canSubmit}
-              className="px-4 py-2.5 rounded-lg text-sm font-medium border border-border-primary text-text-primary hover:bg-surface-secondary transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+              className="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg text-sm font-medium bg-accent-primary text-text-inverse hover:bg-accent-primary-hover transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
             >
+              <Check className="w-4 h-4" aria-hidden />
               {saving ? 'Saving…' : saveLabel}
-            </button>
-          )}
-          {onSaveAndAddAnother && (
-            <button
-              type="button"
-              onClick={onSaveAndAddAnother}
-              disabled={canSubmit}
-              className="px-4 py-2.5 rounded-lg text-sm font-medium bg-accent-primary text-text-inverse hover:bg-accent-primary-hover transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
-            >
-              {saving ? 'Saving…' : saveAndAddAnotherLabel}
             </button>
           )}
         </div>

--- a/src/components/features/decks/CardEditForm.tsx
+++ b/src/components/features/decks/CardEditForm.tsx
@@ -9,9 +9,17 @@ interface CardEditFormProps {
   onCancel?: () => void;
   onSave?: () => void;
   saveLabel?: string;
+  /**
+   * Optional secondary action — typically "Save & Add Another" in the
+   * add-card flow. When provided, it renders as the primary button and
+   * `onSave` becomes a secondary "Save & Close" button. The parent is
+   * responsible for clearing the form and refocusing on success.
+   */
+  onSaveAndAddAnother?: () => void;
+  saveAndAddAnotherLabel?: string;
   /** Auto-focus the front textarea on mount. */
   autoFocus?: boolean;
-  /** Disables the save button and shows a pending label while true. */
+  /** Disables the save buttons and shows a pending label while true. */
   saving?: boolean;
 }
 
@@ -26,9 +34,14 @@ export function CardEditForm({
   onCancel,
   onSave,
   saveLabel = 'Save Changes',
+  onSaveAndAddAnother,
+  saveAndAddAnotherLabel = 'Save & Add Another',
   autoFocus = false,
   saving = false,
 }: CardEditFormProps) {
+  const canSubmit = !front.trim() || !back.trim() || saving;
+  const hasFooter = onCancel || onSave || onSaveAndAddAnother;
+
   return (
     <div className="flex flex-col gap-4 h-full">
       <div>
@@ -40,7 +53,7 @@ export function CardEditForm({
           onChange={(e) => onFrontChange(e.target.value)}
           rows={4}
           autoFocus={autoFocus}
-          className="w-full bg-surface-secondary border border-border-primary rounded-lg px-3 py-2 text-sm text-text-primary resize-none focus:outline-none focus:ring-2 focus:ring-accent-primary"
+          className="w-full bg-surface-secondary border border-border-primary rounded-lg px-3 py-2 text-base text-text-primary resize-none focus:outline-none focus:ring-2 focus:ring-accent-primary"
           placeholder="Question or prompt"
         />
       </div>
@@ -52,13 +65,13 @@ export function CardEditForm({
           value={back}
           onChange={(e) => onBackChange(e.target.value)}
           rows={4}
-          className="w-full bg-surface-secondary border border-border-primary rounded-lg px-3 py-2 text-sm text-text-primary resize-none focus:outline-none focus:ring-2 focus:ring-accent-primary"
+          className="w-full bg-surface-secondary border border-border-primary rounded-lg px-3 py-2 text-base text-text-primary resize-none focus:outline-none focus:ring-2 focus:ring-accent-primary"
           placeholder="Answer"
         />
       </div>
 
-      {(onCancel || onSave) && (
-        <div className="flex gap-2 justify-end mt-auto">
+      {hasFooter && (
+        <div className="flex flex-wrap gap-2 justify-end mt-auto">
           {onCancel && (
             <button
               type="button"
@@ -72,10 +85,20 @@ export function CardEditForm({
             <button
               type="button"
               onClick={onSave}
-              disabled={!front.trim() || !back.trim() || saving}
-              className="px-4 py-2.5 rounded-lg text-sm font-medium bg-accent-primary text-text-inverse hover:bg-accent-primary-hover transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+              disabled={canSubmit}
+              className="px-4 py-2.5 rounded-lg text-sm font-medium border border-border-primary text-text-primary hover:bg-surface-secondary transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
             >
               {saving ? 'Saving…' : saveLabel}
+            </button>
+          )}
+          {onSaveAndAddAnother && (
+            <button
+              type="button"
+              onClick={onSaveAndAddAnother}
+              disabled={canSubmit}
+              className="px-4 py-2.5 rounded-lg text-sm font-medium bg-accent-primary text-text-inverse hover:bg-accent-primary-hover transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+            >
+              {saving ? 'Saving…' : saveAndAddAnotherLabel}
             </button>
           )}
         </div>

--- a/src/components/features/decks/CardPreview.tsx
+++ b/src/components/features/decks/CardPreview.tsx
@@ -1,24 +1,33 @@
 'use client';
 
+import { getCardTier } from '@/lib/memoryStage';
+import { TierBadge } from '@/components/ui/TierBadge';
+
 interface CardPreviewProps {
     front: string;
     index: number;
+    /** Card's SM-2 repetitions count, used to render the tier badge. */
+    repetitions: number;
     onClick: () => void;
 }
 
-export function CardPreview({ front, index, onClick }: CardPreviewProps) {
+export function CardPreview({ front, index, repetitions, onClick }: CardPreviewProps) {
+    const tier = getCardTier(repetitions);
     return (
         <button
             type="button"
             onClick={onClick}
-            className="group h-32 sm:h-[140px] w-full text-left rounded-xl border border-border-primary bg-surface-primary p-4 sm:p-5 shadow-sm
+            className="group relative h-32 sm:h-[140px] w-full text-left rounded-xl border border-border-primary bg-surface-primary p-4 sm:p-5 shadow-sm
                        hover:border-accent-primary/50 hover:shadow-md transition-all duration-200 cursor-pointer
                        focus:outline-none focus:ring-2 focus:ring-accent-primary focus:ring-offset-2 focus:ring-offset-background"
         >
             <div className="flex flex-col h-full">
-                <span className="text-xs font-medium text-text-tertiary mb-2 uppercase tracking-wider">
-                    Card {index + 1}
-                </span>
+                <div className="flex items-center justify-between gap-2 mb-2">
+                    <span className="text-xs font-medium text-text-tertiary uppercase tracking-wider">
+                        Card {index + 1}
+                    </span>
+                    <TierBadge tier={tier} />
+                </div>
                 <p className="text-text-primary text-sm whitespace-pre-wrap break-words line-clamp-3 flex-1">
                     {front || '\u00A0'}
                 </p>

--- a/src/components/ui/TierBadge.tsx
+++ b/src/components/ui/TierBadge.tsx
@@ -1,19 +1,14 @@
 'use client';
 
-import { type CardTier } from '@/lib/memoryStage';
+import { TIER_META, type CardTier } from '@/lib/memoryStage';
 
 /**
- * CSS token name for each tier. Kept here so callers don't have to map
- * tier → token — the badge and any future consumer just look it up.
+ * Tier → CSS color token, looked up from the shared {@link TIER_META} table
+ * so the badge, dashboard widget, and filter all read from one place.
  */
-const TIER_TOKEN: Record<CardTier, string> = {
-  Acorn: 'var(--tier-acorn)',
-  Sprout: 'var(--tier-sprout)',
-  Sapling: 'var(--tier-sapling)',
-  Tree: 'var(--tier-tree)',
-  Grove: 'var(--tier-grove)',
-  Forest: 'var(--tier-forest)',
-};
+const TIER_TOKEN: Record<CardTier, string> = Object.fromEntries(
+  TIER_META.map((t) => [t.tier, t.token])
+) as Record<CardTier, string>;
 
 export interface TierBadgeProps {
   tier: CardTier;

--- a/src/components/ui/TierBadge.tsx
+++ b/src/components/ui/TierBadge.tsx
@@ -1,31 +1,28 @@
 'use client';
 
-import { CARD_TIERS, tierOrdinal, type CardTier } from '@/lib/memoryStage';
+import { type CardTier } from '@/lib/memoryStage';
 
 /**
  * CSS token name for each tier. Kept here so callers don't have to map
  * tier → token — the badge and any future consumer just look it up.
  */
 const TIER_TOKEN: Record<CardTier, string> = {
-  Seed: 'var(--tier-seed)',
+  Acorn: 'var(--tier-acorn)',
   Sprout: 'var(--tier-sprout)',
-  Seedling: 'var(--tier-seedling)',
   Sapling: 'var(--tier-sapling)',
-  Bud: 'var(--tier-bud)',
-  Bloom: 'var(--tier-bloom)',
-  Fruit: 'var(--tier-fruit)',
+  Tree: 'var(--tier-tree)',
+  Grove: 'var(--tier-grove)',
+  Forest: 'var(--tier-forest)',
 };
-
-const TOTAL_TIERS = CARD_TIERS.length;
 
 export interface TierBadgeProps {
   tier: CardTier;
   /**
    * Visual variant:
-   * - `'dot'`    — colored dot + tier name + ordinal, for dense surfaces
-   *                like the card grid. (default)
-   * - `'chip'`   — rounded chip with the tier name, for detail views like
-   *                the card viewer info panel.
+   * - `'dot'`  — colored dot + tier name, for dense surfaces like the card
+   *              grid. (default)
+   * - `'chip'` — rounded chip with the tier name, for detail views like the
+   *              card viewer info panel.
    */
   variant?: 'dot' | 'chip';
   /** Optional extra className for the root element. */
@@ -34,12 +31,11 @@ export interface TierBadgeProps {
 
 /**
  * Tier badge. The dot variant shows a visible colored dot followed by the
- * tier name and its 1-based ordinal out of 7 (e.g. "Sprout · 2/7") so the
- * progression is readable without memorizing the metaphor.
+ * tier name; the chip variant wraps the same in a bordered pill. The
+ * numeric "x/N" ordinal was removed — the name itself is the ranking.
  */
 export function TierBadge({ tier, variant = 'dot', className }: TierBadgeProps) {
   const color = TIER_TOKEN[tier];
-  const level = tierOrdinal(tier) + 1;
 
   if (variant === 'chip') {
     return (
@@ -52,17 +48,14 @@ export function TierBadge({ tier, variant = 'dot', className }: TierBadgeProps) 
           aria-hidden
         />
         <span>{tier}</span>
-        <span className="text-text-tertiary tabular-nums">
-          {level}/{TOTAL_TIERS}
-        </span>
       </span>
     );
   }
 
   return (
     <span
-      className={`inline-flex items-center gap-1 text-xs font-medium text-text-secondary tabular-nums ${className ?? ''}`}
-      title={`${tier} — level ${level} of ${TOTAL_TIERS}`}
+      className={`inline-flex items-center gap-1 text-xs font-medium text-text-secondary ${className ?? ''}`}
+      title={tier}
     >
       <span
         className="size-2.5 rounded-full"
@@ -70,9 +63,6 @@ export function TierBadge({ tier, variant = 'dot', className }: TierBadgeProps) 
         aria-hidden
       />
       <span className="text-text-secondary">{tier}</span>
-      <span className="text-text-tertiary">
-        {level}/{TOTAL_TIERS}
-      </span>
     </span>
   );
 }

--- a/src/components/ui/TierBadge.tsx
+++ b/src/components/ui/TierBadge.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { CARD_TIERS, tierOrdinal, type CardTier } from '@/lib/memoryStage';
+
+/**
+ * CSS token name for each tier. Kept here so callers don't have to map
+ * tier → token — the badge and any future consumer just look it up.
+ */
+const TIER_TOKEN: Record<CardTier, string> = {
+  Seed: 'var(--tier-seed)',
+  Sprout: 'var(--tier-sprout)',
+  Seedling: 'var(--tier-seedling)',
+  Sapling: 'var(--tier-sapling)',
+  Bud: 'var(--tier-bud)',
+  Bloom: 'var(--tier-bloom)',
+  Fruit: 'var(--tier-fruit)',
+};
+
+const TOTAL_TIERS = CARD_TIERS.length;
+
+export interface TierBadgeProps {
+  tier: CardTier;
+  /**
+   * Visual variant:
+   * - `'dot'`    — small colored dot + ordinal, for dense surfaces like
+   *                the card grid. (default)
+   * - `'chip'`   — rounded chip with the tier name, for detail views like
+   *                the card viewer info panel.
+   */
+  variant?: 'dot' | 'chip';
+  /** Optional extra className for the root element. */
+  className?: string;
+}
+
+/**
+ * Compact tier badge. Shows a tier-colored dot (or chip) plus the tier's
+ * 1-based ordinal out of 7 — e.g. "• 4/7" — so the user can gauge progress
+ * at a glance without needing to memorize the plant metaphor.
+ */
+export function TierBadge({ tier, variant = 'dot', className }: TierBadgeProps) {
+  const color = TIER_TOKEN[tier];
+  const level = tierOrdinal(tier) + 1;
+
+  if (variant === 'chip') {
+    return (
+      <span
+        className={`inline-flex items-center gap-1.5 rounded-full border border-border-primary bg-surface-secondary px-2.5 py-1 text-xs font-medium text-text-primary ${className ?? ''}`}
+      >
+        <span
+          className="size-2 rounded-full"
+          style={{ backgroundColor: color }}
+          aria-hidden
+        />
+        <span>{tier}</span>
+        <span className="text-text-tertiary tabular-nums">
+          {level}/{TOTAL_TIERS}
+        </span>
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 text-xs font-medium text-text-tertiary tabular-nums ${className ?? ''}`}
+      title={`${tier} — level ${level} of ${TOTAL_TIERS}`}
+    >
+      <span
+        className="size-2 rounded-full"
+        style={{ backgroundColor: color }}
+        aria-hidden
+      />
+      <span className="text-text-secondary">{level}/{TOTAL_TIERS}</span>
+      <span className="sr-only">{tier}</span>
+    </span>
+  );
+}

--- a/src/components/ui/TierBadge.tsx
+++ b/src/components/ui/TierBadge.tsx
@@ -22,8 +22,8 @@ export interface TierBadgeProps {
   tier: CardTier;
   /**
    * Visual variant:
-   * - `'dot'`    — small colored dot + ordinal, for dense surfaces like
-   *                the card grid. (default)
+   * - `'dot'`    — colored dot + tier name + ordinal, for dense surfaces
+   *                like the card grid. (default)
    * - `'chip'`   — rounded chip with the tier name, for detail views like
    *                the card viewer info panel.
    */
@@ -33,9 +33,9 @@ export interface TierBadgeProps {
 }
 
 /**
- * Compact tier badge. Shows a tier-colored dot (or chip) plus the tier's
- * 1-based ordinal out of 7 — e.g. "• 4/7" — so the user can gauge progress
- * at a glance without needing to memorize the plant metaphor.
+ * Tier badge. The dot variant shows a visible colored dot followed by the
+ * tier name and its 1-based ordinal out of 7 (e.g. "Sprout · 2/7") so the
+ * progression is readable without memorizing the metaphor.
  */
 export function TierBadge({ tier, variant = 'dot', className }: TierBadgeProps) {
   const color = TIER_TOKEN[tier];
@@ -61,16 +61,18 @@ export function TierBadge({ tier, variant = 'dot', className }: TierBadgeProps) 
 
   return (
     <span
-      className={`inline-flex items-center gap-1 text-xs font-medium text-text-tertiary tabular-nums ${className ?? ''}`}
+      className={`inline-flex items-center gap-1 text-xs font-medium text-text-secondary tabular-nums ${className ?? ''}`}
       title={`${tier} — level ${level} of ${TOTAL_TIERS}`}
     >
       <span
-        className="size-2 rounded-full"
+        className="size-2.5 rounded-full"
         style={{ backgroundColor: color }}
         aria-hidden
       />
-      <span className="text-text-secondary">{level}/{TOTAL_TIERS}</span>
-      <span className="sr-only">{tier}</span>
+      <span className="text-text-secondary">{tier}</span>
+      <span className="text-text-tertiary">
+        {level}/{TOTAL_TIERS}
+      </span>
     </span>
   );
 }

--- a/src/lib/filterDeckCards.ts
+++ b/src/lib/filterDeckCards.ts
@@ -1,8 +1,8 @@
-import { getMemoryStage, type MemoryStage } from "@/lib/memoryStage";
+import { getCardTier, type CardTier } from "@/lib/memoryStage";
 
 // ── Filter option types ─────────────────────────────────────────────────────
 
-export type StageFilter = MemoryStage | "all";
+export type StageFilter = CardTier | "all";
 export type DueFilter = "all" | "overdue" | "today" | "upcoming";
 export type CardSortKey = "oldest" | "newest" | "due" | "stage";
 
@@ -79,7 +79,7 @@ export function filterDeckCards(
     }
 
     if (opts.stageFilter !== "all") {
-      if (getMemoryStage(card.repetitions) !== opts.stageFilter) continue;
+      if (getCardTier(card.repetitions) !== opts.stageFilter) continue;
     }
 
     if (opts.dueFilter !== "all") {

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -48,10 +48,13 @@ export interface DeckWithCards extends Deck {
 }
 
 export interface MemoryStages {
-  new: number;
-  learning: number;
-  reviewing: number;
-  mastered: number;
+  seed: number;
+  sprout: number;
+  seedling: number;
+  sapling: number;
+  bud: number;
+  bloom: number;
+  fruit: number;
 }
 
 export interface ReviewForecastBucket {

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -54,17 +54,23 @@ export interface MemoryStages {
   mastered: number;
 }
 
-export interface ReviewForecastDay {
+export interface ReviewForecastBucket {
   date: string;
   count: number;
+  bucket: "hour" | "day";
 }
+
+/** @deprecated — kept as an alias for callers still using the old name. */
+export type ReviewForecastDay = ReviewForecastBucket;
 
 export interface DashboardStats {
   memoryStages: MemoryStages;
-  reviewForecast: ReviewForecastDay[];
+  reviewForecast: ReviewForecastBucket[];
   dueNow: number;
   nextDueAt: number | null;
 }
+
+export type ForecastHorizon = "24h" | "30d";
 
 export type IntervalKey = "1w" | "1m" | "1y";
 
@@ -102,12 +108,16 @@ const qk = {
   deck: (id: number) => ["decks", id] as const,
   deckCards: (id: number) => ["decks", id, "cards"] as const,
   dueCards: (id: number) => ["decks", id, "due"] as const,
-  deckStats: (id: number) => ["decks", id, "stats"] as const,
-  dashboardStats: (tz: string) => ["stats", "dashboard", tz] as const,
+  dashboardStats: (tz: string, horizon: ForecastHorizon) =>
+    ["stats", "dashboard", tz, horizon] as const,
   intervals: (tz: string) => ["stats", "intervals", tz] as const,
   deckIntervals: (id: number, tz: string) => ["decks", id, "intervals", tz] as const,
   activity: (tz: string) => ["stats", "activity", tz] as const,
   search: (q: string) => ["search", q] as const,
+  deckStats: (id: number, tz: string, horizon: ForecastHorizon) =>
+    ["decks", id, "stats", tz, horizon] as const,
+  /** Prefix key for invalidating deck-stats queries across all tz/horizons. */
+  deckStatsPrefix: (id: number) => ["decks", id, "stats"] as const,
 };
 
 // ── Hooks: decks ─────────────────────────────────────────────────────────────────
@@ -191,7 +201,7 @@ export function useCreateCard(deckId: number) {
       qc.invalidateQueries({ queryKey: qk.dueCards(deckId) });
       qc.invalidateQueries({ queryKey: qk.deck(deckId) });
       qc.invalidateQueries({ queryKey: qk.decks });
-      qc.invalidateQueries({ queryKey: qk.deckStats(deckId) });
+      qc.invalidateQueries({ queryKey: qk.deckStatsPrefix(deckId) });
     },
   });
 }
@@ -226,7 +236,7 @@ export function useRecordReview(deckId: number) {
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: qk.deckCards(deckId) });
       qc.invalidateQueries({ queryKey: qk.dueCards(deckId) });
-      qc.invalidateQueries({ queryKey: qk.deckStats(deckId) });
+      qc.invalidateQueries({ queryKey: qk.deckStatsPrefix(deckId) });
       qc.invalidateQueries({ queryKey: qk.decks });
     },
   });
@@ -242,7 +252,7 @@ export function useDeleteCard(deckId: number) {
       qc.invalidateQueries({ queryKey: qk.dueCards(deckId) });
       qc.invalidateQueries({ queryKey: qk.deck(deckId) });
       qc.invalidateQueries({ queryKey: qk.decks });
-      qc.invalidateQueries({ queryKey: qk.deckStats(deckId) });
+      qc.invalidateQueries({ queryKey: qk.deckStatsPrefix(deckId) });
     },
   });
 }
@@ -266,7 +276,7 @@ export function useCompleteSession(deckId: number) {
     }) => api.patch<{ ok: true }>(`/api/decks/${deckId}/study`, input),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["stats"] });
-      qc.invalidateQueries({ queryKey: qk.deckStats(deckId) });
+      qc.invalidateQueries({ queryKey: qk.deckStatsPrefix(deckId) });
       qc.invalidateQueries({ queryKey: ["decks", deckId, "intervals"] });
       qc.invalidateQueries({ queryKey: qk.decks });
     },
@@ -275,12 +285,14 @@ export function useCompleteSession(deckId: number) {
 
 // ── Hooks: stats ─────────────────────────────────────────────────────────────────
 
-export function useDashboardStats(timeZone: string) {
+export function useDashboardStats(timeZone: string, horizon: ForecastHorizon = "30d") {
   const { status } = useSession();
   return useQuery({
-    queryKey: qk.dashboardStats(timeZone),
+    queryKey: qk.dashboardStats(timeZone, horizon),
     queryFn: () =>
-      api.get<DashboardStats>(`/api/stats/dashboard?tz=${encodeURIComponent(timeZone)}`),
+      api.get<DashboardStats>(
+        `/api/stats/dashboard?tz=${encodeURIComponent(timeZone)}&horizon=${horizon}`
+      ),
     enabled: status === "authenticated",
   });
 }
@@ -305,13 +317,17 @@ export function useActivityHistory(timeZone: string) {
   });
 }
 
-export function useDeckStats(deckId: number, timeZone: string) {
+export function useDeckStats(
+  deckId: number,
+  timeZone: string,
+  horizon: ForecastHorizon = "30d"
+) {
   const { status } = useSession();
   return useQuery({
-    queryKey: qk.deckStats(deckId),
+    queryKey: qk.deckStats(deckId, timeZone, horizon),
     queryFn: () =>
       api.get<DashboardStats>(
-        `/api/decks/${deckId}/stats?tz=${encodeURIComponent(timeZone)}`
+        `/api/decks/${deckId}/stats?tz=${encodeURIComponent(timeZone)}&horizon=${horizon}`
       ),
     enabled: status === "authenticated",
   });

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -2,6 +2,7 @@ import {
   useQuery,
   useMutation,
   useQueryClient,
+  keepPreviousData,
 } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { useSession } from "next-auth/react";
@@ -48,13 +49,12 @@ export interface DeckWithCards extends Deck {
 }
 
 export interface MemoryStages {
-  seed: number;
+  acorn: number;
   sprout: number;
-  seedling: number;
   sapling: number;
-  bud: number;
-  bloom: number;
-  fruit: number;
+  tree: number;
+  grove: number;
+  forest: number;
 }
 
 export interface ReviewForecastBucket {
@@ -297,6 +297,7 @@ export function useDashboardStats(timeZone: string, horizon: ForecastHorizon = "
         `/api/stats/dashboard?tz=${encodeURIComponent(timeZone)}&horizon=${horizon}`
       ),
     enabled: status === "authenticated",
+    placeholderData: keepPreviousData,
   });
 }
 
@@ -333,6 +334,7 @@ export function useDeckStats(
         `/api/decks/${deckId}/stats?tz=${encodeURIComponent(timeZone)}&horizon=${horizon}`
       ),
     enabled: status === "authenticated",
+    placeholderData: keepPreviousData,
   });
 }
 
@@ -358,6 +360,7 @@ export function useSearch(query: string, enabled: boolean) {
       api.get<SearchResult>(`/api/search?q=${encodeURIComponent(query)}`),
     enabled: status === "authenticated" && enabled,
     staleTime: 10_000,
+    placeholderData: keepPreviousData,
   });
 }
 

--- a/src/lib/memoryStage.ts
+++ b/src/lib/memoryStage.ts
@@ -1,30 +1,23 @@
 /**
- * Card memory state.
+ * Card memory state — the single source of truth for card progression.
  *
- * Two parallel views over `repetitions`:
+ * Every consumer in the app (badges, dashboard widget, stage filter, stats
+ * backend) reads from this module. There is no longer a parallel "coarse
+ * 4-bucket" stage type — the 6 tiers ARE the stages.
  *
- * - {@link MemoryStage} rolls up into the 4 coarse buckets the stage filter
- *   uses (New / Learning / Reviewing / Mastered). Stable surface — do not
- *   rename without updating the filter and route tests.
+ * Tier boundaries group by SM-2 reality: the early tiers change per review
+ * because intervals jump fast there (1d → 6d → 15d), while the mature tiers
+ * each span multiple reps because by then intervals are weeks/months/years —
+ * one good review shouldn't bump a Tree straight to a Forest.
  *
- * - {@link CardTier} is the finer, user-facing 6-tier "forest" progression
- *   (Acorn → Forest). Grouped by SM-2 reality: the early tiers change per
- *   review because intervals jump fast there (1d → 6d → 15d), while the
- *   mature tiers each span multiple reps because by then intervals are
- *   weeks/months/years — one good review shouldn't bump a Tree straight to
- *   a Forest. Used for per-card badges and the dashboard widget so progress
- *   feels granular and rewarding without misrepresenting how far along a
- *   card actually is.
- *
- * Repetition → tier boundaries (and the matching coarse stage):
- *   0      → Acorn    (New)
- *   1      → Sprout   (Learning)
- *   2      → Sapling  (Learning)
- *   3–4    → Tree     (Reviewing)
- *   5–7    → Grove    (Reviewing)
- *   8+     → Forest   (Mastered)
+ * Repetition → tier:
+ *   0      → Acorn
+ *   1      → Sprout
+ *   2      → Sapling
+ *   3–4    → Tree
+ *   5–7    → Grove
+ *   8+     → Forest
  */
-export type MemoryStage = 'New' | 'Learning' | 'Reviewing' | 'Mastered';
 
 export type CardTier =
   | 'Acorn'
@@ -34,28 +27,9 @@ export type CardTier =
   | 'Grove'
   | 'Forest';
 
-export function getMemoryStage(repetitions: number): MemoryStage {
-    if (repetitions <= 0) return 'New';
-    if (repetitions <= 2) return 'Learning';
-    if (repetitions <= 7) return 'Reviewing';
-    return 'Mastered';
-}
-
 /**
- * Tier → parent stage roll-up. Used by the stage filter so it can map a
- * fine tier back to its coarse bucket.
- */
-export const TIER_TO_STAGE: Record<CardTier, MemoryStage> = {
-    Acorn: 'New',
-    Sprout: 'Learning',
-    Sapling: 'Learning',
-    Tree: 'Reviewing',
-    Grove: 'Reviewing',
-    Forest: 'Mastered',
-};
-
-/**
- * Ordered tier list (lowest → highest). Drives badge color and widget order.
+ * Ordered tier list (lowest → highest). Drives badge order, the dashboard
+ * widget, and the stage-filter dropdown.
  */
 export const CARD_TIERS: CardTier[] = [
     'Acorn',
@@ -82,3 +56,22 @@ export function getCardTier(repetitions: number): CardTier {
 export function tierOrdinal(tier: CardTier): number {
     return CARD_TIERS.indexOf(tier);
 }
+
+/**
+ * Shared per-tier metadata. The single source of truth for tier label and
+ * CSS color token — `TierBadge`, `MemoryStagesWidget`, and the stage-filter
+ * dropdown all read from this table so they can never drift apart.
+ */
+export interface TierMeta {
+    tier: CardTier;
+    /** Display label (same as the tier name, but explicit for the table). */
+    label: string;
+    /** CSS custom property name for the tier color, e.g. `var(--tier-acorn)`. */
+    token: string;
+}
+
+export const TIER_META: TierMeta[] = CARD_TIERS.map((tier) => ({
+    tier,
+    label: tier,
+    token: `var(--tier-${tier.toLowerCase()})`,
+}));

--- a/src/lib/memoryStage.ts
+++ b/src/lib/memoryStage.ts
@@ -1,8 +1,77 @@
+/**
+ * Card memory state.
+ *
+ * Two parallel views over `repetitions`:
+ *
+ * - {@link MemoryStage} rolls up into the 4 coarse buckets the dashboard
+ *   widget and stage filter use (New / Learning / Reviewing / Mastered).
+ *   Stable surface — do not rename without updating the widget, the stage
+ *   filter, and the route tests.
+ *
+ * - {@link CardTier} is the finer, user-facing 7-tier progression with plant
+ *   metaphor names. One tier per `repetitions` value 0-5, and everything
+ *   ≥6 collapses into the final tier. Used for per-card badges and the
+ *   viewer info panel so progress feels more granular and rewarding.
+ */
 export type MemoryStage = 'New' | 'Learning' | 'Reviewing' | 'Mastered';
+
+export type CardTier =
+  | 'Seed'
+  | 'Sprout'
+  | 'Seedling'
+  | 'Sapling'
+  | 'Bud'
+  | 'Bloom'
+  | 'Fruit';
 
 export function getMemoryStage(repetitions: number): MemoryStage {
     if (repetitions === 0) return 'New';
     if (repetitions <= 2) return 'Learning';
     if (repetitions <= 5) return 'Reviewing';
     return 'Mastered';
+}
+
+/**
+ * Tier → parent stage roll-up. Used by the MemoryStages widget so it can keep
+ * showing the 4-bucket bar while badges elsewhere show the finer tier.
+ */
+export const TIER_TO_STAGE: Record<CardTier, MemoryStage> = {
+    Seed: 'New',
+    Sprout: 'Learning',
+    Seedling: 'Learning',
+    Sapling: 'Reviewing',
+    Bud: 'Reviewing',
+    Bloom: 'Reviewing',
+    Fruit: 'Mastered',
+};
+
+/**
+ * Ordered tier list (lowest → highest). Drives badge color and ordinal display.
+ */
+export const CARD_TIERS: CardTier[] = [
+    'Seed',
+    'Sprout',
+    'Seedling',
+    'Sapling',
+    'Bud',
+    'Bloom',
+    'Fruit',
+];
+
+export function getCardTier(repetitions: number): CardTier {
+    if (repetitions <= 0) return 'Seed';
+    if (repetitions === 1) return 'Sprout';
+    if (repetitions === 2) return 'Seedling';
+    if (repetitions === 3) return 'Sapling';
+    if (repetitions === 4) return 'Bud';
+    if (repetitions === 5) return 'Bloom';
+    return 'Fruit';
+}
+
+/**
+ * Zero-based ordinal of a tier in {@link CARD_TIERS}. Handy for "level 4/7"
+ * style badges.
+ */
+export function tierOrdinal(tier: CardTier): number {
+    return CARD_TIERS.indexOf(tier);
 }

--- a/src/lib/memoryStage.ts
+++ b/src/lib/memoryStage.ts
@@ -3,74 +3,81 @@
  *
  * Two parallel views over `repetitions`:
  *
- * - {@link MemoryStage} rolls up into the 4 coarse buckets the dashboard
- *   widget and stage filter use (New / Learning / Reviewing / Mastered).
- *   Stable surface — do not rename without updating the widget, the stage
- *   filter, and the route tests.
+ * - {@link MemoryStage} rolls up into the 4 coarse buckets the stage filter
+ *   uses (New / Learning / Reviewing / Mastered). Stable surface — do not
+ *   rename without updating the filter and route tests.
  *
- * - {@link CardTier} is the finer, user-facing 7-tier progression with plant
- *   metaphor names. One tier per `repetitions` value 0-5, and everything
- *   ≥6 collapses into the final tier. Used for per-card badges and the
- *   viewer info panel so progress feels more granular and rewarding.
+ * - {@link CardTier} is the finer, user-facing 6-tier "forest" progression
+ *   (Acorn → Forest). Grouped by SM-2 reality: the early tiers change per
+ *   review because intervals jump fast there (1d → 6d → 15d), while the
+ *   mature tiers each span multiple reps because by then intervals are
+ *   weeks/months/years — one good review shouldn't bump a Tree straight to
+ *   a Forest. Used for per-card badges and the dashboard widget so progress
+ *   feels granular and rewarding without misrepresenting how far along a
+ *   card actually is.
+ *
+ * Repetition → tier boundaries (and the matching coarse stage):
+ *   0      → Acorn    (New)
+ *   1      → Sprout   (Learning)
+ *   2      → Sapling  (Learning)
+ *   3–4    → Tree     (Reviewing)
+ *   5–7    → Grove    (Reviewing)
+ *   8+     → Forest   (Mastered)
  */
 export type MemoryStage = 'New' | 'Learning' | 'Reviewing' | 'Mastered';
 
 export type CardTier =
-  | 'Seed'
+  | 'Acorn'
   | 'Sprout'
-  | 'Seedling'
   | 'Sapling'
-  | 'Bud'
-  | 'Bloom'
-  | 'Fruit';
+  | 'Tree'
+  | 'Grove'
+  | 'Forest';
 
 export function getMemoryStage(repetitions: number): MemoryStage {
-    if (repetitions === 0) return 'New';
+    if (repetitions <= 0) return 'New';
     if (repetitions <= 2) return 'Learning';
-    if (repetitions <= 5) return 'Reviewing';
+    if (repetitions <= 7) return 'Reviewing';
     return 'Mastered';
 }
 
 /**
- * Tier → parent stage roll-up. Used by the MemoryStages widget so it can keep
- * showing the 4-bucket bar while badges elsewhere show the finer tier.
+ * Tier → parent stage roll-up. Used by the stage filter so it can map a
+ * fine tier back to its coarse bucket.
  */
 export const TIER_TO_STAGE: Record<CardTier, MemoryStage> = {
-    Seed: 'New',
+    Acorn: 'New',
     Sprout: 'Learning',
-    Seedling: 'Learning',
-    Sapling: 'Reviewing',
-    Bud: 'Reviewing',
-    Bloom: 'Reviewing',
-    Fruit: 'Mastered',
+    Sapling: 'Learning',
+    Tree: 'Reviewing',
+    Grove: 'Reviewing',
+    Forest: 'Mastered',
 };
 
 /**
- * Ordered tier list (lowest → highest). Drives badge color and ordinal display.
+ * Ordered tier list (lowest → highest). Drives badge color and widget order.
  */
 export const CARD_TIERS: CardTier[] = [
-    'Seed',
+    'Acorn',
     'Sprout',
-    'Seedling',
     'Sapling',
-    'Bud',
-    'Bloom',
-    'Fruit',
+    'Tree',
+    'Grove',
+    'Forest',
 ];
 
 export function getCardTier(repetitions: number): CardTier {
-    if (repetitions <= 0) return 'Seed';
+    if (repetitions <= 0) return 'Acorn';
     if (repetitions === 1) return 'Sprout';
-    if (repetitions === 2) return 'Seedling';
-    if (repetitions === 3) return 'Sapling';
-    if (repetitions === 4) return 'Bud';
-    if (repetitions === 5) return 'Bloom';
-    return 'Fruit';
+    if (repetitions === 2) return 'Sapling';
+    if (repetitions <= 4) return 'Tree';
+    if (repetitions <= 7) return 'Grove';
+    return 'Forest';
 }
 
 /**
- * Zero-based ordinal of a tier in {@link CARD_TIERS}. Handy for "level 4/7"
- * style badges.
+ * Zero-based ordinal of a tier in {@link CARD_TIERS}. Handy when a consumer
+ * needs the rank rather than the name.
  */
 export function tierOrdinal(tier: CardTier): number {
     return CARD_TIERS.indexOf(tier);

--- a/src/server/queries/stats.ts
+++ b/src/server/queries/stats.ts
@@ -75,19 +75,17 @@ function getHourKey(timestamp: number, timeZone: string): string {
 
 /**
  * Per-tier card counts for the memory-stages chart. One bucket per
- * {@link CardTier} (Seed / Sprout / Seedling / Sapling / Bud / Bloom /
- * Fruit). The older 4-bucket roll-up is gone — the dashboard now shows the
- * full 7-tier progression. The 4-bucket {@link getMemoryStage} roll-up is
- * still used by the stage filter in the deck page.
+ * {@link CardTier} (Acorn / Sprout / Sapling / Tree / Grove / Forest).
+ * The 4-bucket {@link getMemoryStage} roll-up is still used by the stage
+ * filter in the deck page.
  */
 export interface MemoryStages {
-  seed: number;
+  acorn: number;
   sprout: number;
-  seedling: number;
   sapling: number;
-  bud: number;
-  bloom: number;
-  fruit: number;
+  tree: number;
+  grove: number;
+  forest: number;
 }
 
 /**
@@ -237,13 +235,12 @@ function buildCardAggregates(
   nextDueAt: number | null;
 } {
   const memoryStages: MemoryStages = {
-    seed: 0,
+    acorn: 0,
     sprout: 0,
-    seedling: 0,
     sapling: 0,
-    bud: 0,
-    bloom: 0,
-    fruit: 0,
+    tree: 0,
+    grove: 0,
+    forest: 0,
   };
   let dueNow = 0;
   let nextDueAt: number | null = null;

--- a/src/server/queries/stats.ts
+++ b/src/server/queries/stats.ts
@@ -1,6 +1,15 @@
 import { and, eq, gte, sql } from "drizzle-orm";
 import { db } from "@/db";
 import { cards, decks, studySessions } from "@/db/schema";
+import { getCardTier, CARD_TIERS, type CardTier } from "@/lib/memoryStage";
+
+/**
+ * Map each {@link CardTier} to its lowercase key in {@link MemoryStages}.
+ * Built from CARD_TIERS so the order stays in sync with the tier list.
+ */
+const TIER_KEY: Record<CardTier, keyof MemoryStages> = Object.fromEntries(
+  CARD_TIERS.map((tier) => [tier, tier.toLowerCase()])
+) as Record<CardTier, keyof MemoryStages>;
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const MS_PER_HOUR = 60 * 60 * 1000;
@@ -64,11 +73,21 @@ function getHourKey(timestamp: number, timeZone: string): string {
   return `${year}-${month}-${day}T${hour}:00`;
 }
 
+/**
+ * Per-tier card counts for the memory-stages chart. One bucket per
+ * {@link CardTier} (Seed / Sprout / Seedling / Sapling / Bud / Bloom /
+ * Fruit). The older 4-bucket roll-up is gone — the dashboard now shows the
+ * full 7-tier progression. The 4-bucket {@link getMemoryStage} roll-up is
+ * still used by the stage filter in the deck page.
+ */
 export interface MemoryStages {
-  new: number;
-  learning: number;
-  reviewing: number;
-  mastered: number;
+  seed: number;
+  sprout: number;
+  seedling: number;
+  sapling: number;
+  bud: number;
+  bloom: number;
+  fruit: number;
 }
 
 /**
@@ -218,20 +237,20 @@ function buildCardAggregates(
   nextDueAt: number | null;
 } {
   const memoryStages: MemoryStages = {
-    new: 0,
-    learning: 0,
-    reviewing: 0,
-    mastered: 0,
+    seed: 0,
+    sprout: 0,
+    seedling: 0,
+    sapling: 0,
+    bud: 0,
+    bloom: 0,
+    fruit: 0,
   };
   let dueNow = 0;
   let nextDueAt: number | null = null;
 
   for (const card of rows) {
-    const reps = card.repetitions;
-    if (reps === 0) memoryStages.new++;
-    else if (reps <= 2) memoryStages.learning++;
-    else if (reps <= 5) memoryStages.reviewing++;
-    else memoryStages.mastered++;
+    const tier = getCardTier(card.repetitions);
+    memoryStages[TIER_KEY[tier]]++;
 
     const nr = card.nextReview.getTime();
     if (nr <= nowMs) {

--- a/src/server/queries/stats.ts
+++ b/src/server/queries/stats.ts
@@ -76,8 +76,6 @@ function getHourKey(timestamp: number, timeZone: string): string {
 /**
  * Per-tier card counts for the memory-stages chart. One bucket per
  * {@link CardTier} (Acorn / Sprout / Sapling / Tree / Grove / Forest).
- * The 4-bucket {@link getMemoryStage} roll-up is still used by the stage
- * filter in the deck page.
  */
 export interface MemoryStages {
   acorn: number;

--- a/src/server/queries/stats.ts
+++ b/src/server/queries/stats.ts
@@ -3,6 +3,7 @@ import { db } from "@/db";
 import { cards, decks, studySessions } from "@/db/schema";
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const MS_PER_HOUR = 60 * 60 * 1000;
 
 /** Get start of today (midnight) in the given timezone, as a UTC epoch ms. */
 function getStartOfTodayInTimezone(timeZone: string): number {
@@ -40,6 +41,29 @@ function getDayKey(timestamp: number, timeZone: string): string {
   return `${year}-${month}-${day}`;
 }
 
+/**
+ * Get a `YYYY-MM-DDTHH:00` hour key for a timestamp in the given timezone.
+ * Used by the 24h forecast horizon. Hours are zero-padded, 24-hour clock.
+ */
+function getHourKey(timestamp: number, timeZone: string): string {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    hour12: false,
+  }).formatToParts(new Date(timestamp));
+  const year = parts.find((p) => p.type === "year")?.value ?? "0000";
+  const month = parts.find((p) => p.type === "month")?.value ?? "01";
+  const day = parts.find((p) => p.type === "day")?.value ?? "01";
+  // Intl uses "24" instead of "00" for midnight with hour12:false in some
+  // environments; normalize so we always get "00".
+  let hour = parts.find((p) => p.type === "hour")?.value ?? "00";
+  if (hour === "24") hour = "00";
+  return `${year}-${month}-${day}T${hour}:00`;
+}
+
 export interface MemoryStages {
   new: number;
   learning: number;
@@ -48,18 +72,37 @@ export interface MemoryStages {
 }
 
 /**
- * Per-day due-card counts for the next 30 days (today + 29 future days).
- * Cards overdue relative to today roll into today's bucket; cards beyond
- * the window are excluded.
+ * Forecast horizon. `'30d'` (default) buckets by day for 30 days; `'24h'`
+ * buckets by hour for the next 24 hours. The two share a single response
+ * shape — see {@link ReviewForecastBucket} — so the widget can render either
+ * mode with the same code path.
  */
-export interface ReviewForecastDay {
-  date: string; // YYYY-MM-DD in the user's tz
-  count: number;
+export type ForecastHorizon = "24h" | "30d";
+
+export const FORECAST_HORIZONS: ForecastHorizon[] = ["24h", "30d"];
+
+export function normalizeHorizon(value: string | null | undefined): ForecastHorizon {
+  return value === "24h" ? "24h" : "30d";
 }
+
+/**
+ * One bucket in the review forecast. `bucket` tells the client how to format
+ * the X-axis label and how to interpret `date`:
+ * - `'day'`  → `date` is `YYYY-MM-DD` (day key in the user's tz).
+ * - `'hour'` → `date` is `YYYY-MM-DDTHH:00` (hour key in the user's tz).
+ */
+export interface ReviewForecastBucket {
+  date: string;
+  count: number;
+  bucket: "hour" | "day";
+}
+
+/** @deprecated Use {@link ReviewForecastBucket}. Kept as an alias for callers. */
+export type ReviewForecastDay = ReviewForecastBucket;
 
 export interface DashboardStats {
   memoryStages: MemoryStages;
-  reviewForecast: ReviewForecastDay[];
+  reviewForecast: ReviewForecastBucket[];
   /** Number of cards due right now (nextReview <= current time). */
   dueNow: number;
   /** Earliest future nextReview timestamp (epoch ms), null when no cards exist. */
@@ -83,31 +126,60 @@ export interface IntervalStats {
 export type IntervalStatsResponse = Record<IntervalKey, IntervalStats>;
 
 /**
- * Memory stages + 30-day review forecast across all of the user's decks.
- * Uses a single SQL aggregation instead of the Convex version's per-deck fanout.
+ * Build the review forecast buckets for a horizon, given the per-card
+ * `nextReview` timestamps. Pure: takes already-fetched rows + a timeZone +
+ * horizon and returns the ordered bucket list. Shared by
+ * {@link dashboardStats} and {@link deckStats} so the bucketing logic
+ * can't drift between them.
+ *
+ * Horizon semantics:
+ * - `'30d'` → 30 day-buckets starting today. Cards overdue relative to
+ *   today roll into today's bucket; cards beyond 30 days are excluded.
+ * - `'24h'` → 24 hour-buckets starting at the current hour. Cards due
+ *   earlier than the current hour roll into the first (current-hour)
+ *   bucket; cards beyond 24h are excluded.
  */
-export async function dashboardStats(
-  userId: string,
-  timeZone: string
-): Promise<DashboardStats> {
-  const rows = await db
-    .select({
-      repetitions: cards.repetitions,
-      nextReview: cards.nextReview,
-    })
-    .from(cards)
-    .innerJoin(decks, eq(decks.id, cards.deckId))
-    .where(eq(decks.userId, userId));
-
-  const memoryStages: MemoryStages = {
-    new: 0,
-    learning: 0,
-    reviewing: 0,
-    mastered: 0,
-  };
-
+function buildForecast(
+  rows: { nextReview: Date }[],
+  timeZone: string,
+  horizon: ForecastHorizon
+): ReviewForecastBucket[] {
   const nowMs = Date.now();
   const todayStart = getStartOfTodayInTimezone(timeZone);
+
+  if (horizon === "24h") {
+    // Anchor at the start of the current hour in the user's tz. We compute
+    // this from `now` rather than `todayStart` so the first bucket is the
+    // hour we're currently in, not midnight.
+    const hourStart =
+      todayStart +
+      Math.floor((nowMs - todayStart) / MS_PER_HOUR) * MS_PER_HOUR;
+    const horizonEnd = hourStart + 24 * MS_PER_HOUR;
+    const forecastByHour = new Map<string, number>();
+    for (let i = 0; i < 24; i++) {
+      const key = getHourKey(hourStart + i * MS_PER_HOUR, timeZone);
+      forecastByHour.set(key, 0);
+    }
+
+    for (const card of rows) {
+      const nr = card.nextReview.getTime();
+      const bucketStart = nr < hourStart ? hourStart : nr;
+      if (bucketStart < horizonEnd) {
+        const key = getHourKey(bucketStart, timeZone);
+        const existing = forecastByHour.get(key);
+        if (existing !== undefined) forecastByHour.set(key, existing + 1);
+      }
+    }
+
+    const out: ReviewForecastBucket[] = [];
+    for (let i = 0; i < 24; i++) {
+      const key = getHourKey(hourStart + i * MS_PER_HOUR, timeZone);
+      out.push({ date: key, count: forecastByHour.get(key) ?? 0, bucket: "hour" });
+    }
+    return out;
+  }
+
+  // 30d (default)
   const horizonEnd = todayStart + 30 * MS_PER_DAY;
   const forecastByDay = new Map<string, number>();
   for (let i = 0; i < 30; i++) {
@@ -115,6 +187,42 @@ export async function dashboardStats(
     forecastByDay.set(key, 0);
   }
 
+  for (const card of rows) {
+    const nr = card.nextReview.getTime();
+    const bucketStart = nr < todayStart ? todayStart : nr;
+    if (bucketStart < horizonEnd) {
+      const key = getDayKey(bucketStart, timeZone);
+      const existing = forecastByDay.get(key);
+      if (existing !== undefined) forecastByDay.set(key, existing + 1);
+    }
+  }
+
+  const out: ReviewForecastBucket[] = [];
+  for (let i = 0; i < 30; i++) {
+    const key = getDayKey(todayStart + i * MS_PER_DAY, timeZone);
+    out.push({ date: key, count: forecastByDay.get(key) ?? 0, bucket: "day" });
+  }
+  return out;
+}
+
+/**
+ * Accumulate memory stages + due-now/next-due counters from a set of card
+ * rows. Pure helper shared by {@link dashboardStats} and {@link deckStats}.
+ */
+function buildCardAggregates(
+  rows: { repetitions: number; nextReview: Date }[],
+  nowMs: number
+): {
+  memoryStages: MemoryStages;
+  dueNow: number;
+  nextDueAt: number | null;
+} {
+  const memoryStages: MemoryStages = {
+    new: 0,
+    learning: 0,
+    reviewing: 0,
+    mastered: 0,
+  };
   let dueNow = 0;
   let nextDueAt: number | null = null;
 
@@ -131,21 +239,32 @@ export async function dashboardStats(
     } else if (nextDueAt === null || nr < nextDueAt) {
       nextDueAt = nr;
     }
-
-    const bucketStart = nr < todayStart ? todayStart : nr;
-    if (bucketStart < horizonEnd) {
-      const key = getDayKey(bucketStart, timeZone);
-      const existing = forecastByDay.get(key);
-      if (existing !== undefined) forecastByDay.set(key, existing + 1);
-    }
   }
 
-  const reviewForecast: ReviewForecastDay[] = [];
-  for (let i = 0; i < 30; i++) {
-    const key = getDayKey(todayStart + i * MS_PER_DAY, timeZone);
-    reviewForecast.push({ date: key, count: forecastByDay.get(key) ?? 0 });
-  }
+  return { memoryStages, dueNow, nextDueAt };
+}
 
+/**
+ * Memory stages + review forecast across all of the user's decks. Horizon
+ * selects 30 day-buckets (default) or 24 hour-buckets. Uses a single SQL
+ * aggregation instead of the Convex version's per-deck fanout.
+ */
+export async function dashboardStats(
+  userId: string,
+  timeZone: string,
+  horizon: ForecastHorizon = "30d"
+): Promise<DashboardStats> {
+  const rows = await db
+    .select({
+      repetitions: cards.repetitions,
+      nextReview: cards.nextReview,
+    })
+    .from(cards)
+    .innerJoin(decks, eq(decks.id, cards.deckId))
+    .where(eq(decks.userId, userId));
+
+  const { memoryStages, dueNow, nextDueAt } = buildCardAggregates(rows, Date.now());
+  const reviewForecast = buildForecast(rows, timeZone, horizon);
   return { memoryStages, reviewForecast, dueNow, nextDueAt };
 }
 
@@ -153,7 +272,8 @@ export async function dashboardStats(
 export async function deckStats(
   userId: string,
   deckId: number,
-  timeZone: string
+  timeZone: string,
+  horizon: ForecastHorizon = "30d"
 ): Promise<DashboardStats | null> {
   const [deck] = await db
     .select({ id: decks.id })
@@ -170,53 +290,8 @@ export async function deckStats(
     .from(cards)
     .where(eq(cards.deckId, deckId));
 
-  const memoryStages: MemoryStages = {
-    new: 0,
-    learning: 0,
-    reviewing: 0,
-    mastered: 0,
-  };
-
-  const nowMs = Date.now();
-  const todayStart = getStartOfTodayInTimezone(timeZone);
-  const horizonEnd = todayStart + 30 * MS_PER_DAY;
-  const forecastByDay = new Map<string, number>();
-  for (let i = 0; i < 30; i++) {
-    const key = getDayKey(todayStart + i * MS_PER_DAY, timeZone);
-    forecastByDay.set(key, 0);
-  }
-
-  let dueNow = 0;
-  let nextDueAt: number | null = null;
-
-  for (const card of rows) {
-    const reps = card.repetitions;
-    if (reps === 0) memoryStages.new++;
-    else if (reps <= 2) memoryStages.learning++;
-    else if (reps <= 5) memoryStages.reviewing++;
-    else memoryStages.mastered++;
-
-    const nr = card.nextReview.getTime();
-    if (nr <= nowMs) {
-      dueNow++;
-    } else if (nextDueAt === null || nr < nextDueAt) {
-      nextDueAt = nr;
-    }
-
-    const bucketStart = nr < todayStart ? todayStart : nr;
-    if (bucketStart < horizonEnd) {
-      const key = getDayKey(bucketStart, timeZone);
-      const existing = forecastByDay.get(key);
-      if (existing !== undefined) forecastByDay.set(key, existing + 1);
-    }
-  }
-
-  const reviewForecast: ReviewForecastDay[] = [];
-  for (let i = 0; i < 30; i++) {
-    const key = getDayKey(todayStart + i * MS_PER_DAY, timeZone);
-    reviewForecast.push({ date: key, count: forecastByDay.get(key) ?? 0 });
-  }
-
+  const { memoryStages, dueNow, nextDueAt } = buildCardAggregates(rows, Date.now());
+  const reviewForecast = buildForecast(rows, timeZone, horizon);
   return { memoryStages, reviewForecast, dueNow, nextDueAt };
 }
 

--- a/tests/routes/search-import-stats.test.ts
+++ b/tests/routes/search-import-stats.test.ts
@@ -128,7 +128,7 @@ describe("GET /api/stats/dashboard", () => {
     expect(Array.isArray(body.reviewForecast)).toBe(true);
     expect(body.reviewForecast).toHaveLength(30);
     expect(body.reviewForecast[0].bucket).toBe("day");
-    expect(body.memoryStages.new).toBe(1);
+    expect(body.memoryStages.seed).toBe(1);
   });
 
   it("accepts ?horizon=24h and returns 24 hour-buckets", async () => {

--- a/tests/routes/search-import-stats.test.ts
+++ b/tests/routes/search-import-stats.test.ts
@@ -128,7 +128,7 @@ describe("GET /api/stats/dashboard", () => {
     expect(Array.isArray(body.reviewForecast)).toBe(true);
     expect(body.reviewForecast).toHaveLength(30);
     expect(body.reviewForecast[0].bucket).toBe("day");
-    expect(body.memoryStages.seed).toBe(1);
+    expect(body.memoryStages.acorn).toBe(1);
   });
 
   it("accepts ?horizon=24h and returns 24 hour-buckets", async () => {

--- a/tests/routes/search-import-stats.test.ts
+++ b/tests/routes/search-import-stats.test.ts
@@ -127,7 +127,36 @@ describe("GET /api/stats/dashboard", () => {
     expect(body.memoryStages).toBeDefined();
     expect(Array.isArray(body.reviewForecast)).toBe(true);
     expect(body.reviewForecast).toHaveLength(30);
+    expect(body.reviewForecast[0].bucket).toBe("day");
     expect(body.memoryStages.new).toBe(1);
+  });
+
+  it("accepts ?horizon=24h and returns 24 hour-buckets", async () => {
+    const user = await createTestUser(db);
+    const deck = await seedDeck(db, user.id);
+    await seedCard(db, deck.id, { repetitions: 0 });
+    setAuthUserId(user.id);
+    const res = await dashboardRoute(
+      req("http://localhost/api/stats/dashboard?tz=UTC&horizon=24h")
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.reviewForecast).toHaveLength(24);
+    expect(body.reviewForecast.every((b: { bucket: string }) => b.bucket === "hour")).toBe(true);
+  });
+
+  it("treats an unknown horizon as 30d", async () => {
+    const user = await createTestUser(db);
+    const deck = await seedDeck(db, user.id);
+    await seedCard(db, deck.id, { repetitions: 0 });
+    setAuthUserId(user.id);
+    const res = await dashboardRoute(
+      req("http://localhost/api/stats/dashboard?tz=UTC&horizon=bogus")
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.reviewForecast).toHaveLength(30);
+    expect(body.reviewForecast[0].bucket).toBe("day");
   });
 });
 

--- a/tests/server/stats.test.ts
+++ b/tests/server/stats.test.ts
@@ -79,6 +79,41 @@ describe("dashboardStats", () => {
     expect(total).toBe(5);
   });
 
+  it("24h horizon returns 24 hour-buckets tagged bucket='hour'", async () => {
+    const user = await createTestUser(db);
+    const deck = await seedDeck(db, user.id);
+    const now = Date.now();
+    const MS_PER_HOUR = 60 * 60 * 1000;
+    const hourStart = Math.floor(now / MS_PER_HOUR) * MS_PER_HOUR;
+    // Overdue (rolls into current hour bucket).
+    await seedCard(db, deck.id, { nextReview: new Date(now - MS_PER_HOUR) });
+    // Current hour.
+    await seedCard(db, deck.id, { nextReview: new Date(now + 1000) });
+    // 3 hours from now.
+    await seedCard(db, deck.id, {
+      nextReview: new Date(hourStart + 3 * MS_PER_HOUR + 1000),
+    });
+    // 25 hours from now — beyond horizon, excluded.
+    await seedCard(db, deck.id, {
+      nextReview: new Date(hourStart + 25 * MS_PER_HOUR),
+    });
+    const stats = await dashboardStats(user.id, TZ, "24h");
+    expect(stats.reviewForecast).toHaveLength(24);
+    expect(stats.reviewForecast.every((b) => b.bucket === "hour")).toBe(true);
+    expect(stats.reviewForecast[0].count).toBe(2); // overdue + current
+    expect(stats.reviewForecast[3].count).toBe(1);
+    const total = stats.reviewForecast.reduce((s, d) => s + d.count, 0);
+    expect(total).toBe(3);
+  });
+
+  it("24h horizon produces empty buckets for a user with no due cards", async () => {
+    const user = await createTestUser(db);
+    const stats = await dashboardStats(user.id, TZ, "24h");
+    expect(stats.reviewForecast).toHaveLength(24);
+    expect(stats.reviewForecast.every((b) => b.bucket === "hour")).toBe(true);
+    expect(stats.reviewForecast.every((b) => b.count === 0)).toBe(true);
+  });
+
   it("only counts the calling user's cards", async () => {
     const u1 = await createTestUser(db, { email: "u1@x.com" });
     const u2 = await createTestUser(db, { email: "u2@x.com" });

--- a/tests/server/stats.test.ts
+++ b/tests/server/stats.test.ts
@@ -22,13 +22,12 @@ describe("dashboardStats", () => {
     const user = await createTestUser(db);
     const stats = await dashboardStats(user.id, TZ);
     expect(stats.memoryStages).toEqual({
-      seed: 0,
+      acorn: 0,
       sprout: 0,
-      seedling: 0,
       sapling: 0,
-      bud: 0,
-      bloom: 0,
-      fruit: 0,
+      tree: 0,
+      grove: 0,
+      forest: 0,
     });
     expect(stats.reviewForecast).toHaveLength(30);
     expect(stats.reviewForecast.every((d) => d.count === 0)).toBe(true);
@@ -37,23 +36,23 @@ describe("dashboardStats", () => {
   it("classifies cards into tiers by repetitions", async () => {
     const user = await createTestUser(db);
     const deck = await seedDeck(db, user.id);
-    await seedCard(db, deck.id, { repetitions: 0 }); // Seed
+    await seedCard(db, deck.id, { repetitions: 0 }); // Acorn
     await seedCard(db, deck.id, { repetitions: 1 }); // Sprout
-    await seedCard(db, deck.id, { repetitions: 2 }); // Seedling
-    await seedCard(db, deck.id, { repetitions: 3 }); // Sapling
-    await seedCard(db, deck.id, { repetitions: 4 }); // Bud
-    await seedCard(db, deck.id, { repetitions: 5 }); // Bloom
-    await seedCard(db, deck.id, { repetitions: 6 }); // Fruit
-    await seedCard(db, deck.id, { repetitions: 10 }); // Fruit
+    await seedCard(db, deck.id, { repetitions: 2 }); // Sapling
+    await seedCard(db, deck.id, { repetitions: 3 }); // Tree
+    await seedCard(db, deck.id, { repetitions: 4 }); // Tree
+    await seedCard(db, deck.id, { repetitions: 5 }); // Grove
+    await seedCard(db, deck.id, { repetitions: 7 }); // Grove
+    await seedCard(db, deck.id, { repetitions: 8 }); // Forest
+    await seedCard(db, deck.id, { repetitions: 20 }); // Forest
     const stats = await dashboardStats(user.id, TZ);
     expect(stats.memoryStages).toEqual({
-      seed: 1,
+      acorn: 1,
       sprout: 1,
-      seedling: 1,
       sapling: 1,
-      bud: 1,
-      bloom: 1,
-      fruit: 2,
+      tree: 2,
+      grove: 2,
+      forest: 2,
     });
   });
 
@@ -128,10 +127,10 @@ describe("dashboardStats", () => {
     const d1 = await seedDeck(db, u1.id);
     const d2 = await seedDeck(db, u2.id);
     await seedCard(db, d1.id, { repetitions: 0 });
-    await seedCard(db, d2.id, { repetitions: 6 });
+    await seedCard(db, d2.id, { repetitions: 8 });
     const stats = await dashboardStats(u1.id, TZ);
-    expect(stats.memoryStages.fruit).toBe(0);
-    expect(stats.memoryStages.seed).toBe(1);
+    expect(stats.memoryStages.forest).toBe(0);
+    expect(stats.memoryStages.acorn).toBe(1);
   });
 });
 
@@ -148,19 +147,18 @@ describe("deckStats", () => {
     const d1 = await seedDeck(db, user.id, { name: "D1" });
     const d2 = await seedDeck(db, user.id, { name: "D2" });
     await seedCard(db, d1.id, { repetitions: 0 });
-    await seedCard(db, d1.id, { repetitions: 6 });
+    await seedCard(db, d1.id, { repetitions: 8 });
     // d2 cards should be excluded.
     await seedCard(db, d2.id, { repetitions: 0 });
     await seedCard(db, d2.id, { repetitions: 0 });
     const stats = await deckStats(user.id, d1.id, TZ);
     expect(stats?.memoryStages).toEqual({
-      seed: 1,
+      acorn: 1,
       sprout: 0,
-      seedling: 0,
       sapling: 0,
-      bud: 0,
-      bloom: 0,
-      fruit: 1,
+      tree: 0,
+      grove: 0,
+      forest: 1,
     });
     expect(stats?.reviewForecast).toHaveLength(30);
   });

--- a/tests/server/stats.test.ts
+++ b/tests/server/stats.test.ts
@@ -22,30 +22,38 @@ describe("dashboardStats", () => {
     const user = await createTestUser(db);
     const stats = await dashboardStats(user.id, TZ);
     expect(stats.memoryStages).toEqual({
-      new: 0,
-      learning: 0,
-      reviewing: 0,
-      mastered: 0,
+      seed: 0,
+      sprout: 0,
+      seedling: 0,
+      sapling: 0,
+      bud: 0,
+      bloom: 0,
+      fruit: 0,
     });
     expect(stats.reviewForecast).toHaveLength(30);
     expect(stats.reviewForecast.every((d) => d.count === 0)).toBe(true);
   });
 
-  it("classifies cards into memory stages by repetitions", async () => {
+  it("classifies cards into tiers by repetitions", async () => {
     const user = await createTestUser(db);
     const deck = await seedDeck(db, user.id);
-    await seedCard(db, deck.id, { repetitions: 0 }); // New
-    await seedCard(db, deck.id, { repetitions: 1 }); // Learning
-    await seedCard(db, deck.id, { repetitions: 2 }); // Learning
-    await seedCard(db, deck.id, { repetitions: 3 }); // Reviewing
-    await seedCard(db, deck.id, { repetitions: 5 }); // Reviewing
-    await seedCard(db, deck.id, { repetitions: 6 }); // Mastered
+    await seedCard(db, deck.id, { repetitions: 0 }); // Seed
+    await seedCard(db, deck.id, { repetitions: 1 }); // Sprout
+    await seedCard(db, deck.id, { repetitions: 2 }); // Seedling
+    await seedCard(db, deck.id, { repetitions: 3 }); // Sapling
+    await seedCard(db, deck.id, { repetitions: 4 }); // Bud
+    await seedCard(db, deck.id, { repetitions: 5 }); // Bloom
+    await seedCard(db, deck.id, { repetitions: 6 }); // Fruit
+    await seedCard(db, deck.id, { repetitions: 10 }); // Fruit
     const stats = await dashboardStats(user.id, TZ);
     expect(stats.memoryStages).toEqual({
-      new: 1,
-      learning: 2,
-      reviewing: 2,
-      mastered: 1,
+      seed: 1,
+      sprout: 1,
+      seedling: 1,
+      sapling: 1,
+      bud: 1,
+      bloom: 1,
+      fruit: 2,
     });
   });
 
@@ -122,8 +130,8 @@ describe("dashboardStats", () => {
     await seedCard(db, d1.id, { repetitions: 0 });
     await seedCard(db, d2.id, { repetitions: 6 });
     const stats = await dashboardStats(u1.id, TZ);
-    expect(stats.memoryStages.mastered).toBe(0);
-    expect(stats.memoryStages.new).toBe(1);
+    expect(stats.memoryStages.fruit).toBe(0);
+    expect(stats.memoryStages.seed).toBe(1);
   });
 });
 
@@ -146,10 +154,13 @@ describe("deckStats", () => {
     await seedCard(db, d2.id, { repetitions: 0 });
     const stats = await deckStats(user.id, d1.id, TZ);
     expect(stats?.memoryStages).toEqual({
-      new: 1,
-      learning: 0,
-      reviewing: 0,
-      mastered: 1,
+      seed: 1,
+      sprout: 0,
+      seedling: 0,
+      sapling: 0,
+      bud: 0,
+      bloom: 0,
+      fruit: 1,
     });
     expect(stats?.reviewForecast).toHaveLength(30);
   });

--- a/tests/unit/filterDeckCards.test.ts
+++ b/tests/unit/filterDeckCards.test.ts
@@ -113,21 +113,21 @@ describe("filterDeckCards", () => {
       expect(result.map((c) => c.id)).toEqual([2, 3]);
     });
 
-    it("filters to Reviewing (reps 3-5)", () => {
+    it("filters to Reviewing (reps 3-7)", () => {
       const cards = [
         card({ id: 1, repetitions: 2 }),
         card({ id: 2, repetitions: 3 }),
-        card({ id: 3, repetitions: 5 }),
-        card({ id: 4, repetitions: 6 }),
+        card({ id: 3, repetitions: 7 }),
+        card({ id: 4, repetitions: 8 }),
       ];
       const result = filterDeckCards(cards, { ...defaults, stageFilter: "Reviewing" });
       expect(result.map((c) => c.id)).toEqual([2, 3]);
     });
 
-    it("filters to Mastered (reps >= 6)", () => {
+    it("filters to Mastered (reps >= 8)", () => {
       const cards = [
-        card({ id: 1, repetitions: 5 }),
-        card({ id: 2, repetitions: 6 }),
+        card({ id: 1, repetitions: 7 }),
+        card({ id: 2, repetitions: 8 }),
         card({ id: 3, repetitions: 100 }),
       ];
       const result = filterDeckCards(cards, { ...defaults, stageFilter: "Mastered" });

--- a/tests/unit/filterDeckCards.test.ts
+++ b/tests/unit/filterDeckCards.test.ts
@@ -92,45 +92,45 @@ describe("filterDeckCards", () => {
   });
 
   describe("stage filter", () => {
-    it("filters to New (reps=0)", () => {
+    it("filters to Acorn (reps=0)", () => {
       const cards = [
         card({ id: 1, repetitions: 0 }),
         card({ id: 2, repetitions: 1 }),
         card({ id: 3, repetitions: 6 }),
       ];
-      const result = filterDeckCards(cards, { ...defaults, stageFilter: "New" });
+      const result = filterDeckCards(cards, { ...defaults, stageFilter: "Acorn" });
       expect(result.map((c) => c.id)).toEqual([1]);
     });
 
-    it("filters to Learning (reps 1-2)", () => {
+    it("filters to Sprout (reps=1)", () => {
       const cards = [
         card({ id: 1, repetitions: 0 }),
         card({ id: 2, repetitions: 1 }),
         card({ id: 3, repetitions: 2 }),
         card({ id: 4, repetitions: 3 }),
       ];
-      const result = filterDeckCards(cards, { ...defaults, stageFilter: "Learning" });
-      expect(result.map((c) => c.id)).toEqual([2, 3]);
+      const result = filterDeckCards(cards, { ...defaults, stageFilter: "Sprout" });
+      expect(result.map((c) => c.id)).toEqual([2]);
     });
 
-    it("filters to Reviewing (reps 3-7)", () => {
+    it("filters to Tree (reps 3-4)", () => {
       const cards = [
         card({ id: 1, repetitions: 2 }),
         card({ id: 2, repetitions: 3 }),
-        card({ id: 3, repetitions: 7 }),
-        card({ id: 4, repetitions: 8 }),
+        card({ id: 3, repetitions: 4 }),
+        card({ id: 4, repetitions: 5 }),
       ];
-      const result = filterDeckCards(cards, { ...defaults, stageFilter: "Reviewing" });
+      const result = filterDeckCards(cards, { ...defaults, stageFilter: "Tree" });
       expect(result.map((c) => c.id)).toEqual([2, 3]);
     });
 
-    it("filters to Mastered (reps >= 8)", () => {
+    it("filters to Forest (reps >= 8)", () => {
       const cards = [
         card({ id: 1, repetitions: 7 }),
         card({ id: 2, repetitions: 8 }),
         card({ id: 3, repetitions: 100 }),
       ];
-      const result = filterDeckCards(cards, { ...defaults, stageFilter: "Mastered" });
+      const result = filterDeckCards(cards, { ...defaults, stageFilter: "Forest" });
       expect(result.map((c) => c.id)).toEqual([2, 3]);
     });
   });
@@ -213,7 +213,7 @@ describe("filterDeckCards", () => {
       const result = filterDeckCards(cards, {
         ...defaults,
         query: "hola",
-        stageFilter: "New",
+        stageFilter: "Acorn",
         dueFilter: "overdue",
       });
       expect(result.map((c) => c.id)).toEqual([1]);
@@ -269,7 +269,7 @@ describe("isFilterActive", () => {
   it("is true when stage filter is set", () => {
     expect(isFilterActive({
       query: "",
-      stageFilter: "Learning",
+      stageFilter: "Sprout",
       dueFilter: "all",
       sortKey: "oldest",
     })).toBe(true);

--- a/tests/unit/memoryStage.test.ts
+++ b/tests/unit/memoryStage.test.ts
@@ -1,35 +1,11 @@
 import { describe, it, expect } from "vitest";
 import {
-  getMemoryStage,
   getCardTier,
   tierOrdinal,
   CARD_TIERS,
-  TIER_TO_STAGE,
+  TIER_META,
   type CardTier,
 } from "@/lib/memoryStage";
-
-describe("getMemoryStage", () => {
-  it.each([
-    [0, "New"],
-    [1, "Learning"],
-    [2, "Learning"],
-    [3, "Reviewing"],
-    [4, "Reviewing"],
-    [5, "Reviewing"],
-    [7, "Reviewing"],
-    [8, "Mastered"],
-    [10, "Mastered"],
-    [100, "Mastered"],
-  ])("repetitions=%i → %s", (reps, expected) => {
-    expect(getMemoryStage(reps)).toBe(expected);
-  });
-
-  it("handles negative repetitions as New (<=0 branch)", () => {
-    // Not a real state, but the function should not throw. -1 falls into the
-    // `<= 0` bucket, so it reports New.
-    expect(getMemoryStage(-1)).toBe("New");
-  });
-});
 
 describe("getCardTier", () => {
   it.each([
@@ -75,26 +51,29 @@ describe("tierOrdinal", () => {
   });
 });
 
-describe("TIER_TO_STAGE roll-up", () => {
-  it("maps each tier to one of the four coarse stages", () => {
-    const allowed = new Set(["New", "Learning", "Reviewing", "Mastered"]);
-    Object.values(TIER_TO_STAGE).forEach((stage) => {
-      expect(allowed.has(stage)).toBe(true);
+describe("TIER_META", () => {
+  it("has one entry per tier, in CARD_TIERS order", () => {
+    expect(TIER_META.map((t) => t.tier)).toEqual(CARD_TIERS);
+  });
+
+  it("labels match the tier name", () => {
+    TIER_META.forEach((t) => {
+      expect(t.label).toBe(t.tier);
     });
   });
 
-  it("rolls tiers up to the same buckets getMemoryStage uses", () => {
-    const tiers: CardTier[] = CARD_TIERS;
-    // Tier index → repetitions value to cross-check against getMemoryStage.
-    const repsForTier = [0, 1, 2, 3, 5, 8];
-    tiers.forEach((tier, i) => {
-      expect(TIER_TO_STAGE[tier]).toBe(getMemoryStage(repsForTier[i]));
+  it("tokens are the tier's lowercase CSS custom property", () => {
+    TIER_META.forEach((t) => {
+      expect(t.token).toBe(`var(--tier-${t.tier.toLowerCase()})`);
     });
   });
 
-  it("every CardTier is present as a key", () => {
-    CARD_TIERS.forEach((tier) => {
-      expect(TIER_TO_STAGE[tier]).toBeDefined();
+  it("every tier is represented exactly once", () => {
+    const seen = new Set<CardTier>();
+    TIER_META.forEach((t) => {
+      expect(seen.has(t.tier)).toBe(false);
+      seen.add(t.tier);
     });
+    expect(seen.size).toBe(CARD_TIERS.length);
   });
 });

--- a/tests/unit/memoryStage.test.ts
+++ b/tests/unit/memoryStage.test.ts
@@ -16,34 +16,36 @@ describe("getMemoryStage", () => {
     [3, "Reviewing"],
     [4, "Reviewing"],
     [5, "Reviewing"],
-    [6, "Mastered"],
+    [7, "Reviewing"],
+    [8, "Mastered"],
     [10, "Mastered"],
     [100, "Mastered"],
   ])("repetitions=%i → %s", (reps, expected) => {
     expect(getMemoryStage(reps)).toBe(expected);
   });
 
-  it("handles negative repetitions as Learning (<=2 branch)", () => {
+  it("handles negative repetitions as New (<=0 branch)", () => {
     // Not a real state, but the function should not throw. -1 falls into the
-    // `<= 2` bucket, so it reports Learning rather than New.
-    expect(getMemoryStage(-1)).toBe("Learning");
+    // `<= 0` bucket, so it reports New.
+    expect(getMemoryStage(-1)).toBe("New");
   });
 });
 
 describe("getCardTier", () => {
   it.each([
-    [-3, "Seed"],
-    [-1, "Seed"],
-    [0, "Seed"],
+    [-3, "Acorn"],
+    [-1, "Acorn"],
+    [0, "Acorn"],
     [1, "Sprout"],
-    [2, "Seedling"],
-    [3, "Sapling"],
-    [4, "Bud"],
-    [5, "Bloom"],
-    [6, "Fruit"],
-    [7, "Fruit"],
-    [50, "Fruit"],
-    [1000, "Fruit"],
+    [2, "Sapling"],
+    [3, "Tree"],
+    [4, "Tree"],
+    [5, "Grove"],
+    [6, "Grove"],
+    [7, "Grove"],
+    [8, "Forest"],
+    [50, "Forest"],
+    [1000, "Forest"],
   ])("repetitions=%i → %s", (reps, expected) => {
     expect(getCardTier(reps)).toBe(expected);
   });
@@ -58,13 +60,12 @@ describe("getCardTier", () => {
 
 describe("tierOrdinal", () => {
   it("returns 0-based position in CARD_TIERS", () => {
-    expect(tierOrdinal("Seed")).toBe(0);
+    expect(tierOrdinal("Acorn")).toBe(0);
     expect(tierOrdinal("Sprout")).toBe(1);
-    expect(tierOrdinal("Seedling")).toBe(2);
-    expect(tierOrdinal("Sapling")).toBe(3);
-    expect(tierOrdinal("Bud")).toBe(4);
-    expect(tierOrdinal("Bloom")).toBe(5);
-    expect(tierOrdinal("Fruit")).toBe(6);
+    expect(tierOrdinal("Sapling")).toBe(2);
+    expect(tierOrdinal("Tree")).toBe(3);
+    expect(tierOrdinal("Grove")).toBe(4);
+    expect(tierOrdinal("Forest")).toBe(5);
   });
 
   it("every tier's ordinal matches its index in CARD_TIERS", () => {
@@ -83,17 +84,9 @@ describe("TIER_TO_STAGE roll-up", () => {
   });
 
   it("rolls tiers up to the same buckets getMemoryStage uses", () => {
-    const tiers: CardTier[] = [
-      "Seed",
-      "Sprout",
-      "Seedling",
-      "Sapling",
-      "Bud",
-      "Bloom",
-      "Fruit",
-    ];
+    const tiers: CardTier[] = CARD_TIERS;
     // Tier index → repetitions value to cross-check against getMemoryStage.
-    const repsForTier = [0, 1, 2, 3, 4, 5, 6];
+    const repsForTier = [0, 1, 2, 3, 5, 8];
     tiers.forEach((tier, i) => {
       expect(TIER_TO_STAGE[tier]).toBe(getMemoryStage(repsForTier[i]));
     });

--- a/tests/unit/memoryStage.test.ts
+++ b/tests/unit/memoryStage.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { getMemoryStage } from "@/lib/memoryStage";
+import {
+  getMemoryStage,
+  getCardTier,
+  tierOrdinal,
+  CARD_TIERS,
+  TIER_TO_STAGE,
+  type CardTier,
+} from "@/lib/memoryStage";
 
 describe("getMemoryStage", () => {
   it.each([
@@ -20,5 +27,81 @@ describe("getMemoryStage", () => {
     // Not a real state, but the function should not throw. -1 falls into the
     // `<= 2` bucket, so it reports Learning rather than New.
     expect(getMemoryStage(-1)).toBe("Learning");
+  });
+});
+
+describe("getCardTier", () => {
+  it.each([
+    [-3, "Seed"],
+    [-1, "Seed"],
+    [0, "Seed"],
+    [1, "Sprout"],
+    [2, "Seedling"],
+    [3, "Sapling"],
+    [4, "Bud"],
+    [5, "Bloom"],
+    [6, "Fruit"],
+    [7, "Fruit"],
+    [50, "Fruit"],
+    [1000, "Fruit"],
+  ])("repetitions=%i → %s", (reps, expected) => {
+    expect(getCardTier(reps)).toBe(expected);
+  });
+
+  it("never returns undefined for any integer 0..100", () => {
+    for (let i = 0; i <= 100; i++) {
+      const tier = getCardTier(i);
+      expect(CARD_TIERS).toContain(tier);
+    }
+  });
+});
+
+describe("tierOrdinal", () => {
+  it("returns 0-based position in CARD_TIERS", () => {
+    expect(tierOrdinal("Seed")).toBe(0);
+    expect(tierOrdinal("Sprout")).toBe(1);
+    expect(tierOrdinal("Seedling")).toBe(2);
+    expect(tierOrdinal("Sapling")).toBe(3);
+    expect(tierOrdinal("Bud")).toBe(4);
+    expect(tierOrdinal("Bloom")).toBe(5);
+    expect(tierOrdinal("Fruit")).toBe(6);
+  });
+
+  it("every tier's ordinal matches its index in CARD_TIERS", () => {
+    CARD_TIERS.forEach((tier, idx) => {
+      expect(tierOrdinal(tier)).toBe(idx);
+    });
+  });
+});
+
+describe("TIER_TO_STAGE roll-up", () => {
+  it("maps each tier to one of the four coarse stages", () => {
+    const allowed = new Set(["New", "Learning", "Reviewing", "Mastered"]);
+    Object.values(TIER_TO_STAGE).forEach((stage) => {
+      expect(allowed.has(stage)).toBe(true);
+    });
+  });
+
+  it("rolls tiers up to the same buckets getMemoryStage uses", () => {
+    const tiers: CardTier[] = [
+      "Seed",
+      "Sprout",
+      "Seedling",
+      "Sapling",
+      "Bud",
+      "Bloom",
+      "Fruit",
+    ];
+    // Tier index → repetitions value to cross-check against getMemoryStage.
+    const repsForTier = [0, 1, 2, 3, 4, 5, 6];
+    tiers.forEach((tier, i) => {
+      expect(TIER_TO_STAGE[tier]).toBe(getMemoryStage(repsForTier[i]));
+    });
+  });
+
+  it("every CardTier is present as a key", () => {
+    CARD_TIERS.forEach((tier) => {
+      expect(TIER_TO_STAGE[tier]).toBeDefined();
+    });
   });
 });


### PR DESCRIPTION
Closes #61, #63, #65, #66.

## Summary

Four small issues, one PR.

### #63 — Better card state names + badges
- An overhaul to memory tiers.

### #66 — Adjustable forecast time periods
- `dashboardStats` / `deckStats` now take `horizon: '24h' | '30d'` (default `'30d'`). The 24h mode buckets by hour in the user's tz, anchored at the current hour; 30d keeps the existing day-bucket behaviour.
- Each forecast entry is tagged `bucket: 'hour' | 'day'` so the widget knows how to format labels.
- `?horizon=` threaded through the dashboard + deck-stats route handlers and the `useDashboardStats` / `useDeckStats` hooks (horizon is part of the query key; invalidations use a prefix).
- Server + route tests for the 24h path and the unknown-horizon fallback.

### #65 — Right-most-digit X-axis + misleading summary
- Tick interval is computed so the X-axis never shows more than 8 visible labels (was `interval={4}` showing only the right-most digit of each label).
- Header summary rewritten as **`N due now · M scheduled in the next <period>`** so the current bucket and the whole-horizon total stay distinct. No more "23 due" reading when only 5 are actually due.
- Tooltip shows full date+time for hour buckets, weekday+date for day buckets.

### #61 — Repeatedly add cards + mobile zoom
- `CardEditForm` gains an optional `onSaveAndAddAnother`. In the add-card modal it renders as the primary **Save & Add Another**; `onSave` becomes secondary **Save & Close**.
- The modal stays open on save-and-add-another, clears the form, and remounts via `key={addCount}` so `autoFocus` re-triggers on the front textarea. A per-session counter appears in the toast.
- App-like mobile viewport: `maximumScale=1, userScalable=false` in `src/app/layout.tsx` disables pinch-zoom across the whole app. System font scaling still works.
- Form textareas bumped to `text-base` (16px) which also prevents iOS auto-zoom on focus.

## Verification

- `npm run lint` ✓
- `npm run typecheck` ✓
- `npm run test` ✓ (281 tests, including 6 new tests for the 24h horizon path and 3 new tests for tier roll-up)
- Playwright visual QA on the running dev server: dashboard 24h/30d toggle, tier badges on the card grid (1/7 Seed through 7/7 Fruit), add-another flow with toast counter, viewport meta confirmed.

## Known issue (pre-existing, not from this PR)

Clicking a card to open the viewer modal while the forecast chart is mounted triggers a `Maximum update depth exceeded` error in recharts 3.x + React 19 (`ChartDataContextProvider.useEffect`). I reproduced this on `main` (before any of my changes) so it's not caused by this PR — worth a separate issue.

## Commits

- `feat(cards): 7-tier plant progression with badges (#63)`
- `feat(stats): forecast horizon param (24h / 30d) (#66)`
- `feat(forecast): 24h/30d toggle, fixed X-axis labels, clearer summary (#65, #66)`
- `feat(cards): save & add another flow + app-like mobile viewport (#61)`