### PR TITLE
Fix infinite re-render loop in CardViewerModal

### DIFF
--- a/src/app/(protected)/decks/[id]/page.tsx
+++ b/src/app/(protected)/decks/[id]/page.tsx
@@ -96,7 +96,6 @@ export default function DeckDetailPage() {
             stageFilter,
             dueFilter,
             sortKey,
-            now: Date.now(),
             startOfTodayMs,
         }),
         [allCards, debouncedQuery, stageFilter, dueFilter, sortKey, startOfTodayMs]

--- a/src/components/features/decks/CardViewerModal.tsx
+++ b/src/components/features/decks/CardViewerModal.tsx
@@ -49,11 +49,6 @@ export function CardViewerModal({
         setIsEditing(false);
     }, [initialIndex]);
 
-    // Notify parent of navigation so it can track the viewed card by id.
-    useEffect(() => {
-        if (isOpen) onNavigate?.(currentIndex);
-    }, [currentIndex, isOpen, onNavigate]);
-
     const safeIndex = Math.min(currentIndex, cards.length - 1);
     const card = cards[safeIndex];
 
@@ -76,12 +71,22 @@ export function CardViewerModal({
     const canGoNext = currentIndex < cards.length - 1;
 
     const goToPrev = useCallback(() => {
-        if (canGoPrev) { setCurrentIndex((i) => i - 1); setIsFlipped(false); setIsEditing(false); }
-    }, [canGoPrev]);
+        if (!canGoPrev) return;
+        const next = currentIndex - 1;
+        setCurrentIndex(next);
+        setIsFlipped(false);
+        setIsEditing(false);
+        onNavigate?.(next);
+    }, [canGoPrev, currentIndex, onNavigate]);
 
     const goToNext = useCallback(() => {
-        if (canGoNext) { setCurrentIndex((i) => i + 1); setIsFlipped(false); setIsEditing(false); }
-    }, [canGoNext]);
+        if (!canGoNext) return;
+        const next = currentIndex + 1;
+        setCurrentIndex(next);
+        setIsFlipped(false);
+        setIsEditing(false);
+        onNavigate?.(next);
+    }, [canGoNext, currentIndex, onNavigate]);
 
     const handleFlip = useCallback(() => {
         if (!isEditing) setIsFlipped((prev) => !prev);

--- a/src/lib/filterDeckCards.ts
+++ b/src/lib/filterDeckCards.ts
@@ -11,8 +11,6 @@ export interface FilterDeckCardsOptions {
   stageFilter: StageFilter;
   dueFilter: DueFilter;
   sortKey: CardSortKey;
-  /** Current time in ms. Pass Date.now() from callers; fixed in tests. */
-  now: number;
   /** Start-of-today in ms (midnight in the user's tz). Fixed in tests. */
   startOfTodayMs: number;
 }

--- a/src/lib/filterDeckCards.ts
+++ b/src/lib/filterDeckCards.ts
@@ -49,8 +49,8 @@ function toMs(value: string | number | Date): number {
 
 /**
  * Filter and sort a deck's cards in-memory. Pure: no IO, no globals. All
- * time-dependent comparisons are parameterized via `now` and
- * `startOfTodayMs` so the function is deterministic under test.
+ * time-dependent comparisons are parameterized via `startOfTodayMs` so the
+ * function is deterministic under test.
  *
  * Due-status buckets:
  *   - overdue:  nextReview < startOfTodayMs

--- a/tests/unit/filterDeckCards.test.ts
+++ b/tests/unit/filterDeckCards.test.ts
@@ -27,7 +27,6 @@ const defaults = {
   stageFilter: "all" as const,
   dueFilter: "all" as const,
   sortKey: "oldest" as const,
-  now: NOW,
   startOfTodayMs: TODAY_START,
 };
 


### PR DESCRIPTION
## Summary

Fixes the `Maximum update depth exceeded` crash that occurred when clicking any non-first card in the deck view.

## Root cause

PR #64 added a notify-back effect to `CardViewerModal` that created a state-synchronization feedback loop between the parent (`viewingCardId` → `initialIndex` prop) and the child (`currentIndex` state):

1. Clicking a non-first card → parent sets `viewingCardId` → `initialIndex` changes.
2. Effect 1 (sync) scheduled `setCurrentIndex(new)`, but Effect 2 (notify) fired in the **same commit** with the **stale** `currentIndex`, calling `onNavigate(oldIndex)` → parent rewrote `viewingCardId` to the wrong card → `initialIndex` reverted.
3. Effect 1 re-fired, Effect 2 fired with the other stale value → ping-pong forever.

Clicking the **first** card worked because the stale `currentIndex` (0) matched the new id, so React bailed on the redundant state write. (recharts appeared in the stack trace only as collateral — it's mounted on the page and got caught in the render storm.)

## Fix

Remove the notify-back effect entirely. The parent only needs to learn about navigation that originates **inside** the viewer (prev / next / keyboard arrows), not the `initialIndex` sync — the parent set that itself when it opened the modal. `onNavigate?.(newIndex)` is now called directly from `goToPrev` / `goToNext` with the computed post-navigation index.

No memoization hacks, no refs — just a single authoritative call site for parent updates.

## Verification

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run test` ✅ (259 tests)
- Playwright MCP: clicking cards 2, 10, and 15 opens cleanly; arrow-key + button navigation updates the parent; info panel works; sort change with modal open is stable.